### PR TITLE
layout re-arranging

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -444,12 +444,12 @@
 							<h2 class="text-lg font-semibold">Section Order</h2>
 							<button class="secondary text-sm" onclick={resetSectionOrder}>Reset to Default</button>
 						</div>
-						<p class="text-sm text-gray-600">Drag sections or use the arrows to reorder how they appear in your resume.</p>
+						<p class="text-sm text-gray-600">Use the arrows to reorder how sections appear in your resume.</p>
 						<div class="space-y-2">
 							{#each data.sectionOrder as sectionId, i}
 								<div class="flex items-center gap-3 bg-gray-50 border rounded-lg p-3">
 									<div class="flex flex-col gap-1">
-										<button 
+										<button
 											class="p-1 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed"
 											onclick={() => moveSection(i, 'up')}
 											disabled={i === 0}
@@ -457,7 +457,7 @@
 										>
 											<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path></svg>
 										</button>
-										<button 
+										<button
 											class="p-1 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed"
 											onclick={() => moveSection(i, 'down')}
 											disabled={i === data.sectionOrder.length - 1}
@@ -561,93 +561,76 @@
 							</div>
 						</div>
 
-						<!-- Profile -->
-						{#if data.profile.summary}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Profile</h2>
-								<p style="color: {data.colors.textColor}; line-height: 1.3;">{data.profile.summary}</p>
-							</div>
-						{/if}
-
-						<!-- Education -->
-						{#if data.education.length > 0}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Education</h2>
-								{#each data.education as edu}
-									<div class="mb-1">
-										<div class="flex justify-between"><span class="font-bold">{edu.institution}</span><span class="font-bold">{edu.location}</span></div>
-										<div class="flex justify-between" style="font-size: 8px;"><span>{edu.degree}, {edu.major}</span><span>{formatDate(edu.startDate)} - {formatDate(edu.endDate)}</span></div>
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each edu.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
-									</div>
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Projects -->
-						{#if data.projects.length > 0}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Projects</h2>
-								{#each data.projects as project}
-									<div class="mb-1">
-										<span class="font-bold" style="color: {project.url ? data.colors.linkColor : data.colors.textColor}">{project.name}</span>
-										{#if project.stack} | <span class="font-bold">{project.stack}</span>{/if}
-										{#if project.award} · {project.award}{/if}
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each project.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
-									</div>
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Experience -->
-						{#if data.workExperience.length > 0}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Experience</h2>
-								{#each data.workExperience as work}
-									<div class="mb-1">
-										<div class="flex justify-between"><span class="font-bold">{work.title}</span><span class="font-bold">{formatDate(work.startDate)} - {work.isPresent ? 'Present' : formatDate(work.endDate)}</span></div>
-										<div class="flex justify-between" style="font-size: 8px;"><span>{work.company}</span><span>{work.location}</span></div>
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each work.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
-									</div>
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Leadership -->
-						{#if data.leadership.length > 0}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Leadership</h2>
-								{#each data.leadership as lead}
-									<div class="mb-1">
-										<div class="flex justify-between"><span class="font-bold">{lead.title}</span><span class="font-bold">{formatDate(lead.startDate)} - {lead.isPresent ? 'Present' : formatDate(lead.endDate)}</span></div>
-										<div class="flex justify-between" style="font-size: 8px;"><span>{lead.organization}</span><span>{lead.location}</span></div>
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each lead.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
-									</div>
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Skills -->
-						{#if data.skills.length > 0}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Skills</h2>
-								{#each data.skills.filter(s => s.category && s.skills) as skill}
-									<p style="font-size: 8px;"><span class="font-bold">{skill.category}:</span> {skill.skills}</p>
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Achievements -->
-						{#if data.achievements.length > 0}
-							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Achievements / Certifications</h2>
-								{#each data.achievements.filter(a => a.title) as achievement}
-									<div class="mb-1">
-										<span class="font-bold">{achievement.title}</span>{#if achievement.date} | {achievement.date}{/if}
-										{#if achievement.description}<p style="font-size: 8px;">{achievement.description}</p>{/if}
-									</div>
-								{/each}
-							</div>
-						{/if}
+						{#each data.sectionOrder as sectionId}
+							{#if sectionId === 'profile' && data.profile.summary}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Profile</h2>
+									<p style="color: {data.colors.textColor}; line-height: 1.3;">{data.profile.summary}</p>
+								</div>
+							{:else if sectionId === 'education' && data.education.length > 0}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Education</h2>
+									{#each data.education as edu}
+										<div class="mb-1">
+											<div class="flex justify-between"><span class="font-bold">{edu.institution}</span><span class="font-bold">{edu.location}</span></div>
+											<div class="flex justify-between" style="font-size: 8px;"><span>{edu.degree}, {edu.major}</span><span>{formatDate(edu.startDate)} - {formatDate(edu.endDate)}</span></div>
+											<ul class="list-disc list-inside" style="font-size: 8px;">{#each edu.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										</div>
+									{/each}
+								</div>
+							{:else if sectionId === 'projects' && data.projects.length > 0}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Projects</h2>
+									{#each data.projects as project}
+										<div class="mb-1">
+											<span class="font-bold" style="color: {project.url ? data.colors.linkColor : data.colors.textColor}">{project.name}</span>
+											{#if project.stack} | <span class="font-bold">{project.stack}</span>{/if}
+											{#if project.award} · {project.award}{/if}
+											<ul class="list-disc list-inside" style="font-size: 8px;">{#each project.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										</div>
+									{/each}
+								</div>
+							{:else if sectionId === 'experience' && data.workExperience.length > 0}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Experience</h2>
+									{#each data.workExperience as work}
+										<div class="mb-1">
+											<div class="flex justify-between"><span class="font-bold">{work.title}</span><span class="font-bold">{formatDate(work.startDate)} - {work.isPresent ? 'Present' : formatDate(work.endDate)}</span></div>
+											<div class="flex justify-between" style="font-size: 8px;"><span>{work.company}</span><span>{work.location}</span></div>
+											<ul class="list-disc list-inside" style="font-size: 8px;">{#each work.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										</div>
+									{/each}
+								</div>
+							{:else if sectionId === 'leadership' && data.leadership.length > 0}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Leadership</h2>
+									{#each data.leadership as lead}
+										<div class="mb-1">
+											<div class="flex justify-between"><span class="font-bold">{lead.title}</span><span class="font-bold">{formatDate(lead.startDate)} - {lead.isPresent ? 'Present' : formatDate(lead.endDate)}</span></div>
+											<div class="flex justify-between" style="font-size: 8px;"><span>{lead.organization}</span><span>{lead.location}</span></div>
+											<ul class="list-disc list-inside" style="font-size: 8px;">{#each lead.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										</div>
+									{/each}
+								</div>
+							{:else if sectionId === 'skills' && data.skills.length > 0}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Skills</h2>
+									{#each data.skills.filter(s => s.category && s.skills) as skill}
+										<p style="font-size: 8px;"><span class="font-bold">{skill.category}:</span> {skill.skills}</p>
+									{/each}
+								</div>
+							{:else if sectionId === 'achievements' && data.achievements.length > 0}
+								<div class="mb-2">
+									<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Achievements / Certifications</h2>
+									{#each data.achievements.filter(a => a.title) as achievement}
+										<div class="mb-1">
+											<span class="font-bold">{achievement.title}</span>{#if achievement.date} | {achievement.date}{/if}
+											{#if achievement.description}<p style="font-size: 8px;">{achievement.description}</p>{/if}
+										</div>
+									{/each}
+								</div>
+							{/if}
+						{/each}
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
This pull request refactors the resume section rendering logic in `web/src/routes/+page.svelte` to support customizable section ordering. Instead of hardcoding the order of sections, it now iterates over `data.sectionOrder`, rendering each section based on its presence and content. Additionally, the drag-and-drop instruction text was updated to reflect the new ordering mechanism.

Resume section rendering improvements:

* Changed section rendering to iterate over `data.sectionOrder`, allowing users to customize the order in which sections appear in their resume. Each section is conditionally rendered based on its ID and content. 
* Removed hardcoded section blocks and replaced them with a loop and conditional logic for each section, improving maintainability and flexibility.

UI text update:

* Updated the instruction text to remove mention of dragging sections, reflecting the new ordering mechanism ("Use the arrows to reorder how sections appear in your resume.").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Resume sections now dynamically render based on available data and display in your specified order.
  * Updated guidance text to clarify how to reorder sections using arrow controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->