### PR TITLE
color/font size fixes

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -547,12 +547,12 @@
 					<div
 						bind:this={previewRef}
 						class="bg-white shadow-lg overflow-auto"
-						style="width: 100%; max-width: 510px; aspect-ratio: 8.5 / 11; font-family: Georgia, serif; font-size: 9px; padding: 24px;"
+						style="width: 100%; max-width: 510px; aspect-ratio: 8.5 / 11; font-family: Georgia, serif; font-size: {data.fonts.baseSize}px; color: {data.colors.textColor}; padding: 24px;"
 					>
 						<!-- Header -->
 						<div class="text-center mb-2">
-							<h1 class="text-base font-bold uppercase" style="color: {data.colors.headColor}">{data.personalInfo.name || 'Your Name'}</h1>
-							<div class="flex flex-wrap justify-center gap-x-1" style="color: {data.colors.textColor}; font-size: 8px;">
+							<h1 class="font-bold uppercase" style="color: {data.colors.headColor}; font-size: {data.fonts.nameSize}px;">{data.personalInfo.name || 'Your Name'}</h1>
+							<div class="flex flex-wrap justify-center gap-x-1" style="color: {data.colors.textColor}; font-size: {data.fonts.contactSize}px;">
 								{#if data.personalInfo.email}<span style="color: {data.colors.linkColor}">{data.personalInfo.email}</span> |{/if}
 								{#if data.personalInfo.website}<span style="color: {data.colors.linkColor}">{data.personalInfo.website}</span> |{/if}
 								{#if data.personalInfo.linkedin}<span style="color: {data.colors.linkColor}">linkedin.com/in/{data.personalInfo.linkedin}</span> |{/if}
@@ -564,7 +564,7 @@
 						<!-- Profile -->
 						{#if data.profile.summary}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Profile</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Profile</h2>
 								<p style="color: {data.colors.textColor}; line-height: 1.3;">{data.profile.summary}</p>
 							</div>
 						{/if}
@@ -572,12 +572,12 @@
 						<!-- Education -->
 						{#if data.education.length > 0}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Education</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Education</h2>
 								{#each data.education as edu}
 									<div class="mb-1">
 										<div class="flex justify-between"><span class="font-bold">{edu.institution}</span><span class="font-bold">{edu.location}</span></div>
-										<div class="flex justify-between" style="font-size: 8px;"><span>{edu.degree}, {edu.major}</span><span>{formatDate(edu.startDate)} - {formatDate(edu.endDate)}</span></div>
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each edu.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										<div class="flex justify-between"><span>{edu.degree}, {edu.major}</span><span>{formatDate(edu.startDate)} - {formatDate(edu.endDate)}</span></div>
+										<ul class="list-disc list-inside">{#each edu.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
 									</div>
 								{/each}
 							</div>
@@ -586,13 +586,13 @@
 						<!-- Projects -->
 						{#if data.projects.length > 0}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Projects</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Projects</h2>
 								{#each data.projects as project}
 									<div class="mb-1">
 										<span class="font-bold" style="color: {project.url ? data.colors.linkColor : data.colors.textColor}">{project.name}</span>
 										{#if project.stack} | <span class="font-bold">{project.stack}</span>{/if}
 										{#if project.award} · {project.award}{/if}
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each project.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										<ul class="list-disc list-inside">{#each project.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
 									</div>
 								{/each}
 							</div>
@@ -601,12 +601,12 @@
 						<!-- Experience -->
 						{#if data.workExperience.length > 0}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Experience</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Experience</h2>
 								{#each data.workExperience as work}
 									<div class="mb-1">
 										<div class="flex justify-between"><span class="font-bold">{work.title}</span><span class="font-bold">{formatDate(work.startDate)} - {work.isPresent ? 'Present' : formatDate(work.endDate)}</span></div>
-										<div class="flex justify-between" style="font-size: 8px;"><span>{work.company}</span><span>{work.location}</span></div>
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each work.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										<div class="flex justify-between"><span>{work.company}</span><span>{work.location}</span></div>
+										<ul class="list-disc list-inside">{#each work.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
 									</div>
 								{/each}
 							</div>
@@ -615,12 +615,12 @@
 						<!-- Leadership -->
 						{#if data.leadership.length > 0}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Leadership</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Leadership</h2>
 								{#each data.leadership as lead}
 									<div class="mb-1">
 										<div class="flex justify-between"><span class="font-bold">{lead.title}</span><span class="font-bold">{formatDate(lead.startDate)} - {lead.isPresent ? 'Present' : formatDate(lead.endDate)}</span></div>
-										<div class="flex justify-between" style="font-size: 8px;"><span>{lead.organization}</span><span>{lead.location}</span></div>
-										<ul class="list-disc list-inside" style="font-size: 8px;">{#each lead.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
+										<div class="flex justify-between"><span>{lead.organization}</span><span>{lead.location}</span></div>
+										<ul class="list-disc list-inside">{#each lead.bullets.filter(b=>b) as b}<li>{b}</li>{/each}</ul>
 									</div>
 								{/each}
 							</div>
@@ -629,9 +629,9 @@
 						<!-- Skills -->
 						{#if data.skills.length > 0}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Skills</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Skills</h2>
 								{#each data.skills.filter(s => s.category && s.skills) as skill}
-									<p style="font-size: 8px;"><span class="font-bold">{skill.category}:</span> {skill.skills}</p>
+									<p><span class="font-bold">{skill.category}:</span> {skill.skills}</p>
 								{/each}
 							</div>
 						{/if}
@@ -639,11 +639,11 @@
 						<!-- Achievements -->
 						{#if data.achievements.length > 0}
 							<div class="mb-2">
-								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: 10px;">Achievements / Certifications</h2>
+								<h2 class="uppercase tracking-wider pb-0.5 mb-0.5 font-normal" style="color: {data.colors.accentColor}; border-bottom: 1px solid {data.colors.accentColor}; font-size: {data.fonts.headingSize}px;">Achievements / Certifications</h2>
 								{#each data.achievements.filter(a => a.title) as achievement}
 									<div class="mb-1">
 										<span class="font-bold">{achievement.title}</span>{#if achievement.date} | {achievement.date}{/if}
-										{#if achievement.description}<p style="font-size: 8px;">{achievement.description}</p>{/if}
+										{#if achievement.description}<p>{achievement.description}</p>{/if}
 									</div>
 								{/each}
 							</div>


### PR DESCRIPTION
This pull request updates the resume preview styling in `web/src/routes/+page.svelte` to use customizable font sizes and colors from the `data` object, making the layout more flexible and consistent with user preferences. Section headings, text, and list items now use values from `data.fonts` and `data.colors` instead of hardcoded styles.

Styling and customization improvements:

* Section headings (`h2`) throughout the resume now use `data.fonts.headingSize` for font size, allowing dynamic adjustment based on user settings. 
* The main preview container and header (`h1`) use font sizes and colors from `data.fonts.baseSize`, `data.fonts.nameSize`, `data.fonts.contactSize`, and `data.colors.textColor`, instead of fixed values.
* List items and text in education, projects, experience, leadership, skills, and achievements sections no longer use hardcoded font sizes, relying instead on inherited or customized styles for improved consistency. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Resume preview styling now uses consistent, customizable font sizes and colors across all sections (headers, contact information, section headings, and body text).
  * Removed hard-coded style values to improve flexibility and consistency throughout the resume preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->