### PR TITLE
Feat/onetonlinescrapperautofill

### DIFF
--- a/docs/superpowers/specs/2026-09-02-onet-job-tailoring-design.md
+++ b/docs/superpowers/specs/2026-09-02-onet-job-tailoring-design.md
@@ -11,9 +11,22 @@ O*NET publishes exactly that reference data for roughly 900 occupations. This fe
 
 ## Scope
 
-A read-only reference drawer plus explicit insert actions. No AI. The existing OpenAI extraction pipeline is untouched.
+A reference drawer plus explicit insert actions, and an optional one-click AI pass.
 
-Out of scope: gap analysis against the current resume, AI rewriting of bullets, occupation recommendations.
+The drawer itself is deterministic: browsing it changes nothing, and every manual insert copies O*NET's wording verbatim into a destination the user picks.
+
+Out of scope: gap analysis against the current resume, occupation recommendations.
+
+### Added after the first release: Auto-tailor
+
+A button that sends the resume plus the occupation code to OpenAI, which selects the items the resume can already support, rewrites each in the resume's voice, and assigns it to a target. Results apply immediately, highlighted purple for review.
+
+Two risks this design has to absorb:
+
+- **Overstated experience.** Rewriting an O*NET task into a resume bullet can assert something the candidate has never done. The prompt's first grounding rule forbids claims the resume does not already evidence, the button's helper text warns about it, and every applied edit is highlighted for review. This mitigates but does not eliminate the risk; the user must read the purple text.
+- **Hallucinated destinations.** The model can return a `targetId` it was never offered. `validateEdits` drops any edit whose id is not in the exact allowed set for its kind, along with wrong-kind ids, empty text, duplicates, and anything past `MAX_EDITS`. Bad entries are dropped individually so one does not lose the rest of the batch.
+
+`POST /api/onet/tailor` takes `{ resume, code }` and is explicitly uncached, unlike the other O*NET routes, because its response is personal to the caller. It fetches the occupation server-side rather than trusting a client-supplied copy. Contact details are excluded from the prompt.
 
 ## Data source
 

--- a/docs/superpowers/specs/2026-09-02-onet-job-tailoring-design.md
+++ b/docs/superpowers/specs/2026-09-02-onet-job-tailoring-design.md
@@ -1,0 +1,166 @@
+# O*NET Job Tailoring — Design
+
+Date: 2026-09-02
+Status: Approved for implementation
+
+## Problem
+
+A user writing a resume in this builder has no reference for what a target occupation actually involves. They guess at which duties, tools, and competencies matter, and phrase bullets from memory.
+
+O*NET publishes exactly that reference data for roughly 900 occupations. This feature puts it beside the editor and lets the user pull items directly into the resume.
+
+## Scope
+
+A read-only reference drawer plus explicit insert actions. No AI. The existing OpenAI extraction pipeline is untouched.
+
+Out of scope: gap analysis against the current resume, AI rewriting of bullets, occupation recommendations.
+
+## Data source
+
+Use the official O*NET Web Services API, not HTML scraping.
+
+- Base URL: `https://api-v2.onetcenter.org`
+- Auth: `X-API-Key` header. Free developer key from <https://services.onetcenter.org/developer/signup>. The key cannot be passed as a query parameter.
+- Format: JSON.
+- Rate limits: best-effort, unspecified numbers. O*NET's own documentation recommends caching common requests, which this design does.
+
+Scraping onetonline.org was rejected: the same data is a documented endpoint, and HTML parsing would break on any redesign.
+
+### Endpoints used
+
+| Purpose | Path |
+| --- | --- |
+| Keyword search | `/online/search?keyword=` |
+| Overview (title, description) | `/online/occupations/{code}` |
+| Tasks | `/online/occupations/{code}/summary/tasks` |
+| Technology skills | `/online/occupations/{code}/summary/technology_skills` |
+| Skills | `/online/occupations/{code}/summary/skills` |
+| Knowledge | `/online/occupations/{code}/summary/knowledge` |
+| Abilities | `/online/occupations/{code}/summary/abilities` |
+| Detailed work activities | `/online/occupations/{code}/summary/detailed_work_activities` |
+
+There is no combined report endpoint. Selecting an occupation fans out to all seven requests server-side and returns one merged payload.
+
+### Partial availability
+
+O*NET states some services are not available for all occupations. A section that returns 404 or 422 degrades to an empty array and its name is added to `unavailable[]` on the payload. It must not fail the whole request. The drawer renders "Not published for this occupation" for those sections.
+
+## Architecture
+
+### Server
+
+`src/lib/server/onet.ts` holds all logic with no SvelteKit imports, mirroring how `src/lib/server/extraction.ts` separates from its route so it stays unit testable.
+
+- `isValidOnetCode(code)` — O*NET-SOC codes match `^\d{2}-\d{4}\.\d{2}$`. Validate before interpolating into a URL path. Rejects path traversal and query injection.
+- `onetFetch(path, key)` — adds `X-API-Key` and `Accept: application/json`.
+- `searchOccupations(keyword, key)` — returns `OnetOccupationRef[]`.
+- `fetchOccupation(code, key)` — `Promise.all` over the seven endpoints, normalized to `OnetOccupation`.
+- `mapOnetError(err)` — mirrors `mapOpenAIError`: 401/403 to `auth`, 404/422 to `not_found`, 429 to `rate_limited`, 5xx or network failure to `upstream_unavailable`, else `unknown`.
+- Normalizers are separate exported pure functions per section so each is testable against a recorded fixture.
+
+Routes:
+
+- `src/routes/api/onet/search/+server.ts` — `GET ?keyword=`
+- `src/routes/api/onet/occupation/[code]/+server.ts` — `GET`
+
+Both set `export const prerender = false` and `Cache-Control: public, max-age=0, s-maxage=604800, stale-while-revalidate=86400`. O*NET updates on an annual cadence, so a one-week edge TTL is safe.
+
+### Vercel free tier
+
+Verified against Vercel's published Hobby limits:
+
+- Max function duration 300s. A seven-way parallel fetch completes in roughly 1 to 2 seconds.
+- Max response body 4.5 MB. The merged payload is tens of KB.
+- CDN caching of function responses via `s-maxage` and `stale-while-revalidate` is available on all plans.
+
+No KV store, no database, no new npm dependency.
+
+### Types
+
+New file `src/lib/onet-types.ts`, kept out of `types.ts` which already carries the whole resume model.
+
+```ts
+interface OnetOccupationRef { code: string; title: string; brightOutlook: boolean }
+interface OnetItem { id: string; text: string }
+interface OnetScaleItem { id: string; name: string; description: string }
+interface OnetTechnology { category: string; examples: string[]; hot: boolean }
+interface OnetOccupation {
+  code: string; title: string; description: string;
+  tasks: OnetItem[];
+  detailedWorkActivities: OnetItem[];
+  skills: OnetScaleItem[];
+  knowledge: OnetScaleItem[];
+  abilities: OnetScaleItem[];
+  technologySkills: OnetTechnology[];
+  unavailable: string[];
+}
+```
+
+### Client state
+
+`src/lib/onet-store.ts` uses the same shape as `resumeStore`, with its own localStorage key `onetSelection`, holding only `{ code, title }`.
+
+`ResumeData`, `mergeWithDefaults`, and `typst-generator.ts` are not modified. The target occupation is not resume content and must never reach the PDF.
+
+The fetched `OnetOccupation` payload is not persisted. It is refetched on load, which the edge cache makes cheap.
+
+### UI
+
+`src/lib/components/OnetDrawer.svelte` is a fixed right slide-over over the whole app, so O*NET data stays visible while editing any tab.
+
+- Opened from a "Tailor" button in `AppHeader.svelte`, next to Upload.
+- Backdrop, Escape to close, `translate-x` transition.
+- Debounced (300ms) search box, then a result list, then on select fetch and render collapsible sections.
+
+`src/lib/components/OnetInsertMenu.svelte` is the per-item dropdown picker.
+
+### Insert behavior
+
+The picker is explicit per insert. No sticky target, no fixed destination.
+
+| Item type | Picker lists | Effect |
+| --- | --- | --- |
+| Task, detailed work activity | `workExperience` entries ("Title at Company"), `projects` entries | Appends text to that entry's `bullets` |
+| Technology skill | `skills` categories, plus "New category" | Appends the example name to that category's comma-separated string |
+| Skill, knowledge, ability | `skills` categories, plus "New category" | Appends the competency name |
+
+Every insert registers its dotted field path in the existing `aiFilled` set from `ai-highlight.ts`, so inserted text renders purple until the user edits it.
+
+Consequence: the review banner in `+page.svelte` currently reads "AI filled the highlighted (purple) fields". O*NET text is not AI-generated. The copy is generalized to cover both sources rather than building a second highlight system.
+
+## Error handling
+
+Server errors map to a stable `{ error: { code, message } }` shape matching the existing `/api/extract` contract, so the drawer renders messages the same way `UploadModal` does.
+
+| Code | Status | Message |
+| --- | --- | --- |
+| `invalid_code` | 400 | That job code isn't valid. |
+| `not_found` | 404 | No O*NET data for that occupation. |
+| `rate_limited` | 429 | O*NET is busy right now. Wait a moment and retry. |
+| `auth` | 502 | O*NET access is misconfigured (API key). |
+| `upstream_unavailable` | 502 | Can't reach O*NET. Check your connection and retry. |
+| `unknown` | 500 | Something went wrong. Please try again. |
+
+A missing `ONET_API_KEY` surfaces as `auth`, matching how a missing OpenAI key behaves today.
+
+## Environment
+
+`ONET_API_KEY` read at request time via `$env/dynamic/private`, not `$env/static/private`. Static private env would fail the build outright when the variable is absent; dynamic makes a missing key a runtime `auth` error instead, which is what the error table above specifies. Added to `.env.example` and to the Vercel project environment.
+
+## Attribution
+
+O*NET data is CC BY 4.0 and attribution is mandatory. `AppFooter.svelte` gains the required text verbatim:
+
+> This site incorporates information from O*NET Web Services by the U.S. Department of Labor, Employment and Training Administration (USDOL/ETA). O*NET is a trademark of USDOL/ETA.
+
+with "O*NET Web Services" linking to <https://services.onetcenter.org/> and a CC BY 4.0 license link.
+
+## Testing
+
+Vitest, alongside the existing suites.
+
+- `onet.test.ts` — code validation rejects injection and malformed codes; each section normalizer against recorded fixture JSON; partial-section failure degrades to `unavailable` rather than throwing; error mapping table.
+- `onet-store.test.ts` — persistence round-trip, corrupt JSON tolerated.
+- `onet-insert.test.ts` — insert into an experience entry, into a project, into an existing skills category, into a new category; correct highlight paths registered; no mutation of unrelated resume fields.
+
+Fixtures are recorded JSON committed under `src/lib/server/fixtures/`, so tests require no API key and no network.

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,6 @@
 # OpenAI API key used by the /api/extract serverless endpoint
 OPENAI_API_KEY=
+
+# O*NET Web Services key used by the /api/onet endpoints.
+# Free developer signup: https://services.onetcenter.org/developer/signup
+ONET_API_KEY=

--- a/web/src/lib/components/AppFooter.svelte
+++ b/web/src/lib/components/AppFooter.svelte
@@ -1,4 +1,44 @@
 <footer class="bg-white border-t border-gray-200 mt-auto">
+	<!--
+		Required attribution for O*NET Web Services, using the official badge and
+		wording supplied by O*NET. Do not reword the text or restyle the badge.
+	-->
+	<div class="max-w-7xl mx-auto px-4 pt-4 sm:px-6 lg:px-8 flex items-center gap-4 text-xs text-gray-500">
+		<a
+			href="https://services.onetcenter.org/"
+			target="_blank"
+			rel="noopener noreferrer"
+			title="This site incorporates information from O*NET Web Services. Click to learn more."
+			class="shrink-0"
+		>
+			<img
+				src="https://www.onetcenter.org/image/link/onet-in-it.svg"
+				alt="O*NET in-it"
+				width="130"
+				height="60"
+				loading="lazy"
+				class="w-32.5 h-15 border-none"
+			/>
+		</a>
+		<p>
+			This site incorporates information from
+			<a
+				href="https://services.onetcenter.org/"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="hover:text-gray-700 underline">O*NET Web Services</a
+			>
+			by the U.S. Department of Labor, Employment and Training Administration (USDOL/ETA). O*NET&reg; is a trademark of USDOL/ETA.
+			O*NET Web Services Data License by U.S. Department of Labor, Employment and Training Administration is licensed under
+			a
+			<a
+				href="https://creativecommons.org/licenses/by/4.0/"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="hover:text-gray-700 underline">Creative Commons Attribution 4.0 International License</a
+			>.
+		</p>
+	</div>
 	<div class="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8 flex items-center justify-between text-sm text-gray-500">
 		<p>
 			{new Date().getFullYear()} Resume Builder -

--- a/web/src/lib/components/AppFooter.svelte
+++ b/web/src/lib/components/AppFooter.svelte
@@ -1,59 +1,60 @@
+<!--
+	Single row so the footer stays short enough for the viewport-locked layout in
+	+page.svelte. The O*NET badge and credit line are required attribution using
+	the official markup: do not reword the text or restyle the badge.
+-->
 <footer class="bg-white border-t border-gray-200 mt-auto">
-	<!--
-		Required attribution for O*NET Web Services, using the official badge and
-		wording supplied by O*NET. Do not reword the text or restyle the badge.
-	-->
-	<div class="max-w-7xl mx-auto px-4 pt-4 sm:px-6 lg:px-8 flex items-center gap-4 text-xs text-gray-500">
-		<a
-			href="https://services.onetcenter.org/"
-			target="_blank"
-			rel="noopener noreferrer"
-			title="This site incorporates information from O*NET Web Services. Click to learn more."
-			class="shrink-0"
-		>
-			<img
-				src="https://www.onetcenter.org/image/link/onet-in-it.svg"
-				alt="O*NET in-it"
-				width="130"
-				height="60"
-				loading="lazy"
-				class="w-32.5 h-15 border-none"
-			/>
-		</a>
-		<p>
-			This site incorporates information from
+	<div
+		class="max-w-7xl mx-auto px-4 py-2 sm:px-6 lg:px-8 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 text-[11px] leading-tight text-gray-500"
+	>
+		<div class="flex items-center gap-3">
 			<a
 				href="https://services.onetcenter.org/"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="hover:text-gray-700 underline">O*NET Web Services</a
+				title="This site incorporates information from O*NET Web Services. Click to learn more."
+				class="shrink-0"
 			>
-			by the U.S. Department of Labor, Employment and Training Administration (USDOL/ETA). O*NET&reg; is a trademark of USDOL/ETA.
-			O*NET Web Services Data License by U.S. Department of Labor, Employment and Training Administration is licensed under
-			a
-			<a
-				href="https://creativecommons.org/licenses/by/4.0/"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="hover:text-gray-700 underline">Creative Commons Attribution 4.0 International License</a
-			>.
-		</p>
-	</div>
-	<div class="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8 flex items-center justify-between text-sm text-gray-500">
-		<p>
+				<img
+					src="https://www.onetcenter.org/image/link/onet-in-it.svg"
+					alt="O*NET in-it"
+					width="130"
+					height="60"
+					loading="lazy"
+					class="w-32.5 h-15 border-none"
+				/>
+			</a>
+			<p class="max-w-2xl">
+				This site incorporates information from
+				<a
+					href="https://services.onetcenter.org/"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="hover:text-gray-700 underline">O*NET Web Services</a
+				>
+				by the U.S. Department of Labor, Employment and Training Administration (USDOL/ETA). O*NET&reg; is a trademark of
+				USDOL/ETA. O*NET Web Services Data License by U.S. Department of Labor, Employment and Training Administration is
+				licensed under a
+				<a
+					href="https://creativecommons.org/licenses/by/4.0/"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="hover:text-gray-700 underline">Creative Commons Attribution 4.0 International License</a
+				>.
+			</p>
+		</div>
+
+		<p class="shrink-0">
 			{new Date().getFullYear()} Resume Builder -
 			<a href="https://asternberg.xyz" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700"
 				>Austin Sternberg</a
 			>
+			&middot;
+			<a href="https://typst.app" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700">Typst</a>
+			Layout by
+			<a href="https://monster0506.dev/" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700"
+				>TJ Raklovits</a
+			>
 		</p>
-		<div class="flex gap-4">
-			<p>
-				<a href="https://typst.app" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700">Typst</a>
-				Layout by
-				<a href="https://monster0506.dev/" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700"
-					>TJ Raklovits</a
-				>
-			</p>
-		</div>
 	</div>
 </footer>

--- a/web/src/lib/components/AppHeader.svelte
+++ b/web/src/lib/components/AppHeader.svelte
@@ -6,6 +6,7 @@
 		isOverOnePage,
 		onDownload,
 		onUpload,
+		onTailor,
 	}: {
 		showCode: boolean;
 		isCompiling: boolean;
@@ -13,6 +14,7 @@
 		isOverOnePage: boolean;
 		onDownload: () => void;
 		onUpload: () => void;
+		onTailor: () => void;
 	} = $props();
 </script>
 
@@ -22,6 +24,7 @@
 			<h1 class="text-2xl font-bold text-gray-900">Resume Builder</h1>
 			<div class="flex gap-2">
 				<button class="secondary" onclick={onUpload}>Upload your Resume</button>
+				<button class="secondary" onclick={onTailor}>Tailor to a Job</button>
 				<button class="secondary" onclick={() => (showCode = !showCode)}>
 					{showCode ? 'Preview' : 'Typst'}
 				</button>

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -1,0 +1,367 @@
+<script lang="ts">
+	import { fly, fade } from 'svelte/transition';
+	import { onetStore } from '$lib/onet-store';
+	import { onetSectionLabels } from '$lib/onet-types';
+	import type { OnetOccupation, OnetOccupationRef, OnetSectionName } from '$lib/onet-types';
+	import type { ResumeData } from '$lib/types';
+	import { appendBullet, appendSkill, appendSkillToNewCategory, bulletTargets, skillTargets } from '$lib/onet-insert';
+	import { aiFilled } from '$lib/ai-highlight';
+	import OnetInsertMenu from './OnetInsertMenu.svelte';
+
+	let {
+		open = $bindable(),
+		data = $bindable(),
+		onInserted,
+	}: { open: boolean; data: ResumeData; onInserted: () => void } = $props();
+
+	let query = $state('');
+	let results = $state<OnetOccupationRef[]>([]);
+	let searching = $state(false);
+	let searched = $state(false);
+	let occupation = $state<OnetOccupation | null>(null);
+	let loading = $state(false);
+	let error = $state('');
+	let expanded = $state<OnetSectionName | null>('tasks');
+	// Key of the item whose insert menu is showing, e.g. "tasks:1234".
+	let menuFor = $state<string | null>(null);
+	let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const GENERIC_ERROR = "Can't reach O*NET. Check your connection and retry.";
+
+	async function readError(res: Response): Promise<string> {
+		try {
+			const body = await res.json();
+			return body?.error?.message ?? GENERIC_ERROR;
+		} catch {
+			return GENERIC_ERROR;
+		}
+	}
+
+	async function runSearch(keyword: string) {
+		if (!keyword.trim()) {
+			results = [];
+			searched = false;
+			return;
+		}
+		searching = true;
+		error = '';
+		try {
+			const res = await fetch(`/api/onet/search?keyword=${encodeURIComponent(keyword)}`);
+			if (!res.ok) {
+				error = await readError(res);
+				results = [];
+			} else {
+				results = (await res.json()).occupations;
+			}
+			searched = true;
+		} catch {
+			error = GENERIC_ERROR;
+			results = [];
+		} finally {
+			searching = false;
+		}
+	}
+
+	function onQueryInput() {
+		clearTimeout(searchTimer);
+		const keyword = query;
+		searchTimer = setTimeout(() => runSearch(keyword), 300);
+	}
+
+	async function load(ref: OnetOccupationRef) {
+		onetStore.select(ref);
+		onetStore.saveToStorage();
+		results = [];
+		query = '';
+		searched = false;
+		loading = true;
+		error = '';
+		occupation = null;
+		try {
+			const res = await fetch(`/api/onet/occupation/${encodeURIComponent(ref.code)}`);
+			if (!res.ok) {
+				error = await readError(res);
+			} else {
+				occupation = (await res.json()).occupation;
+			}
+		} catch {
+			error = GENERIC_ERROR;
+		} finally {
+			loading = false;
+		}
+	}
+
+	function changeOccupation() {
+		occupation = null;
+		error = '';
+		onetStore.clear();
+		onetStore.saveToStorage();
+	}
+
+	// Reload the occupation the user picked in a previous session. The edge cache
+	// makes this cheap, which is why the payload itself is never persisted.
+	$effect(() => {
+		if (!open || occupation || loading || error) return;
+		const saved = $onetStore;
+		if (saved) load(saved);
+	});
+
+	function applyPaths(paths: (string | null)[]) {
+		const kept = paths.filter((p): p is string => p !== null);
+		for (const path of kept) aiFilled.add(path);
+		if (kept.length > 0) onInserted();
+		menuFor = null;
+	}
+
+	function insertBullet(kind: 'experience' | 'project', id: string, text: string) {
+		const result = appendBullet(data, kind, id, text);
+		data = result.data;
+		applyPaths([result.path]);
+	}
+
+	function insertSkill(categoryId: string, name: string) {
+		const result = appendSkill(data, categoryId, name);
+		data = result.data;
+		applyPaths([result.path]);
+	}
+
+	function insertNewSkillCategory(category: string, name: string) {
+		const result = appendSkillToNewCategory(data, category, name);
+		data = result.data;
+		applyPaths(result.paths);
+	}
+
+	function toggleMenu(key: string) {
+		menuFor = menuFor === key ? null : key;
+	}
+
+	function toggleSection(name: OnetSectionName) {
+		expanded = expanded === name ? null : name;
+		menuFor = null;
+	}
+
+	function close() {
+		open = false;
+		menuFor = null;
+		// Clear the error so reopening retries. The auto-load effect below bails
+		// while `error` is set, so a stale one would wedge the drawer shut.
+		error = '';
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') close();
+	}
+
+	// Bullet-shaped sections (tasks, work activities) go into experience or
+	// projects; everything else goes into a skills category.
+	let bulletDests = $derived(bulletTargets(data));
+	let skillDests = $derived(skillTargets(data));
+
+	function sectionCount(occ: OnetOccupation, name: OnetSectionName): number {
+		if (name === 'technologySkills') return occ.technologySkills.reduce((n, c) => n + c.examples.length, 0);
+		return (occ[name] as unknown[]).length;
+	}
+
+	const SECTION_ORDER: OnetSectionName[] = [
+		'tasks',
+		'technologySkills',
+		'detailedWorkActivities',
+		'skills',
+		'knowledge',
+		'abilities',
+	];
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+	<div class="fixed inset-0 z-40 bg-black/30" transition:fade={{ duration: 150 }} onclick={close}></div>
+
+	<aside
+		class="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-2xl"
+		transition:fly={{ x: 400, duration: 200 }}
+		aria-label="Tailor to a job"
+	>
+		<div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+			<h2 class="text-lg font-semibold">Tailor to a job</h2>
+			<button class="secondary px-2 py-1 text-sm" onclick={close} aria-label="Close">X</button>
+		</div>
+
+		<div class="flex-1 overflow-y-auto px-4 py-4">
+			{#if !occupation}
+				<label for="onet-search">Search O*NET occupations</label>
+				<input
+					id="onet-search"
+					type="text"
+					bind:value={query}
+					oninput={onQueryInput}
+					placeholder="software developer, nurse, electrician..."
+				/>
+
+				{#if searching}
+					<p class="mt-3 text-sm text-gray-500">Searching...</p>
+				{:else if error}
+					<p class="mt-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+				{:else if results.length > 0}
+					<ul class="mt-3 space-y-1">
+						{#each results as ref (ref.code)}
+							<li>
+								<button
+									class="w-full rounded border border-gray-200 bg-white px-3 py-2 text-left text-sm font-normal hover:border-blue-300 hover:bg-blue-50"
+									onclick={() => load(ref)}
+								>
+									<span class="font-medium">{ref.title}</span>
+									{#if ref.brightOutlook}
+										<span class="ml-2 rounded bg-yellow-100 px-1.5 py-0.5 text-xs text-yellow-800">Bright outlook</span>
+									{/if}
+									<span class="mt-0.5 block text-xs text-gray-500">{ref.code}</span>
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{:else if searched}
+					<p class="mt-3 text-sm text-gray-500">No occupations matched that search.</p>
+				{:else}
+					<p class="mt-3 text-sm text-gray-500">
+						Pick the job you're applying for and its O*NET tasks, technologies, and competencies show up here. Insert
+						any of them straight into your resume.
+					</p>
+				{/if}
+			{:else}
+				<div class="mb-4 border-b border-gray-200 pb-3">
+					<div class="flex items-start justify-between gap-2">
+						<h3 class="font-semibold">{occupation.title}</h3>
+						<button class="secondary shrink-0 px-2 py-1 text-xs" onclick={changeOccupation}>Change</button>
+					</div>
+					<p class="mt-1 text-xs text-gray-500">{occupation.code}</p>
+					<p class="mt-2 text-sm text-gray-600">{occupation.description}</p>
+				</div>
+
+				{#each SECTION_ORDER as name (name)}
+					{@const unavailable = occupation.unavailable.includes(name)}
+					<div class="mb-2 rounded border border-gray-200">
+						<button
+							class="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-medium hover:bg-gray-50"
+							onclick={() => toggleSection(name)}
+							disabled={unavailable}
+						>
+							<span class:text-gray-400={unavailable}>{onetSectionLabels[name]}</span>
+							<span class="text-xs text-gray-500">
+								{unavailable ? 'not published' : sectionCount(occupation, name)}
+							</span>
+						</button>
+
+						{#if expanded === name && !unavailable}
+							<div class="space-y-2 border-t border-gray-200 px-3 py-2">
+								{#if name === 'tasks' || name === 'detailedWorkActivities'}
+									{#each occupation[name] as item (item.id)}
+										{@const key = `${name}:${item.id}`}
+										<div>
+											<div class="flex items-start gap-2">
+												<p class="flex-1 text-sm text-gray-700">{item.text}</p>
+												<button
+													class="secondary shrink-0 px-2 py-0.5 text-xs"
+													onclick={() => toggleMenu(key)}
+													aria-label="Insert into resume">+</button
+												>
+											</div>
+											{#if menuFor === key}
+												<OnetInsertMenu
+													targets={bulletDests}
+													emptyMessage="Add an experience or project first."
+													onPick={(id) => {
+														const target = bulletDests.find((t) => t.id === id)!;
+														insertBullet(target.kind, id, item.text);
+													}}
+												/>
+											{/if}
+										</div>
+									{/each}
+								{:else if name === 'technologySkills'}
+									{#each occupation.technologySkills as category (category.category)}
+										<div>
+											<p class="text-xs font-medium text-gray-500">{category.category}</p>
+											<div class="mt-1 space-y-1">
+												{#each category.examples as example (example.name)}
+													{@const key = `tech:${category.category}:${example.name}`}
+													<div>
+														<div class="flex items-center gap-2">
+															<p class="flex-1 text-sm text-gray-700">
+																{example.name}
+																{#if example.hot}
+																	<span class="ml-1 rounded bg-orange-100 px-1 py-0.5 text-xs text-orange-800">hot</span
+																	>
+																{/if}
+															</p>
+															<button
+																class="secondary shrink-0 px-2 py-0.5 text-xs"
+																onclick={() => toggleMenu(key)}
+																aria-label="Insert into resume">+</button
+															>
+														</div>
+														{#if menuFor === key}
+															<OnetInsertMenu
+																targets={skillDests}
+																allowNew
+																onPick={(id) => insertSkill(id, example.name)}
+																onCreate={(cat) => insertNewSkillCategory(cat, example.name)}
+															/>
+														{/if}
+													</div>
+												{/each}
+											</div>
+										</div>
+									{/each}
+								{:else}
+									{#each occupation[name] as element (element.id)}
+										{@const key = `${name}:${element.id}`}
+										<div>
+											<div class="flex items-start gap-2">
+												<div class="flex-1">
+													<p class="text-sm font-medium text-gray-700">{element.name}</p>
+													<p class="text-xs text-gray-500">{element.description}</p>
+												</div>
+												<button
+													class="secondary shrink-0 px-2 py-0.5 text-xs"
+													onclick={() => toggleMenu(key)}
+													aria-label="Insert into resume">+</button
+												>
+											</div>
+											{#if menuFor === key}
+												<OnetInsertMenu
+													targets={skillDests}
+													allowNew
+													onPick={(id) => insertSkill(id, element.name)}
+													onCreate={(cat) => insertNewSkillCategory(cat, element.name)}
+												/>
+											{/if}
+										</div>
+									{/each}
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			{/if}
+
+			{#if loading}
+				<p class="mt-3 text-sm text-gray-500">Loading occupation data...</p>
+			{/if}
+			{#if error && occupation}
+				<p class="mt-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+			{/if}
+		</div>
+
+		<p class="border-t border-gray-200 px-4 py-2 text-xs text-gray-500">
+			Data from
+			<a
+				href="https://services.onetcenter.org/"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="underline hover:text-gray-700">O*NET Web Services</a
+			>
+			(USDOL/ETA), CC BY 4.0.
+		</p>
+	</aside>
+{/if}

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -2,9 +2,10 @@
 	import { fly, fade } from 'svelte/transition';
 	import { onetStore } from '$lib/onet-store';
 	import { onetSectionLabels } from '$lib/onet-types';
-	import type { OnetOccupation, OnetOccupationRef, OnetSectionName } from '$lib/onet-types';
+	import type { OnetOccupation, OnetOccupationRef, OnetSectionName, TailorEdit } from '$lib/onet-types';
 	import type { ResumeData } from '$lib/types';
 	import { appendBullet, appendSkill, appendSkillToNewCategory, bulletTargets, skillTargets } from '$lib/onet-insert';
+	import { applyTailorEdits } from '$lib/onet-apply';
 	import { aiFilled } from '$lib/ai-highlight';
 	import OnetInsertMenu from './OnetInsertMenu.svelte';
 
@@ -24,6 +25,9 @@
 	let expanded = $state<OnetSectionName | null>('tasks');
 	// Key of the item whose insert menu is showing, e.g. "tasks:1234".
 	let menuFor = $state<string | null>(null);
+	let tailoring = $state(false);
+	let tailorError = $state('');
+	let tailorNote = $state('');
 	let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
 	const GENERIC_ERROR = "Can't reach O*NET. Check your connection and retry.";
@@ -94,6 +98,8 @@
 	function changeOccupation() {
 		occupation = null;
 		error = '';
+		tailorError = '';
+		tailorNote = '';
 		onetStore.clear();
 		onetStore.saveToStorage();
 	}
@@ -129,6 +135,45 @@
 		const result = appendSkillToNewCategory(data, category, name);
 		data = result.data;
 		applyPaths(result.paths);
+	}
+
+	// One click sends the resume plus the occupation code to the AI pass and
+	// applies whatever comes back, highlighted for review.
+	async function autoTailor() {
+		if (!occupation || tailoring) return;
+		tailoring = true;
+		tailorError = '';
+		tailorNote = '';
+		try {
+			const res = await fetch('/api/onet/tailor', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ resume: data, code: occupation.code }),
+			});
+			if (!res.ok) {
+				tailorError = await readError(res);
+				return;
+			}
+
+			const edits: TailorEdit[] = (await res.json()).edits ?? [];
+			const result = applyTailorEdits(data, edits);
+			data = result.data;
+			applyPaths(result.paths);
+
+			if (result.paths.length === 0) {
+				tailorNote =
+					edits.length === 0
+						? "The AI didn't find anything in this occupation your resume can already back up."
+						: 'Everything the AI suggested is already on your resume.';
+			} else {
+				const n = result.paths.length;
+				tailorNote = `Added ${n} ${n === 1 ? 'item' : 'items'}, highlighted in purple. Check the wording before exporting.`;
+			}
+		} catch {
+			tailorError = GENERIC_ERROR;
+		} finally {
+			tailoring = false;
+		}
 	}
 
 	function toggleMenu(key: string) {
@@ -241,6 +286,24 @@
 						wording in, and you pick which experience, project, or skill category it lands in. Anything you add is highlighted
 						purple so you can reword it.
 					</p>
+
+					<button
+						class="primary mt-3 w-full text-sm disabled:opacity-60"
+						onclick={autoTailor}
+						disabled={tailoring || bulletDests.length + skillDests.length === 0}
+					>
+						{tailoring ? 'Tailoring...' : 'Auto-tailor with AI'}
+					</button>
+					<p class="mt-1 text-xs text-gray-500">
+						Picks the items that fit your background, rewrites them in your voice, and adds them straight in. Review the
+						purple text before you export &mdash; AI can overstate what you have actually done.
+					</p>
+					{#if tailorNote}
+						<p class="mt-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-700">{tailorNote}</p>
+					{/if}
+					{#if tailorError}
+						<p class="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700">{tailorError}</p>
+					{/if}
 				</div>
 
 				{#each SECTION_ORDER as name (name)}

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -224,8 +224,8 @@
 					<p class="mt-3 text-sm text-gray-500">No occupations matched that search.</p>
 				{:else}
 					<p class="mt-3 text-sm text-gray-500">
-						Pick the job you're applying for and its O*NET tasks, technologies, and competencies show up here. Insert
-						any of them straight into your resume.
+						Pick the job you're applying for and its O*NET tasks, technologies, and competencies show up here. Each one
+						gets a <span class="font-medium">+ Add</span> button that copies its wording into a part of your resume you choose.
 					</p>
 				{/if}
 			{:else}
@@ -236,6 +236,11 @@
 					</div>
 					<p class="mt-1 text-xs text-gray-500">{occupation.code}</p>
 					<p class="mt-2 text-sm text-gray-600">{occupation.description}</p>
+					<p class="mt-3 rounded border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900">
+						Nothing here changes your resume on its own. Use <span class="font-medium">+ Add</span> on any item to copy its
+						wording in, and you pick which experience, project, or skill category it lands in. Anything you add is highlighted
+						purple so you can reword it.
+					</p>
 				</div>
 
 				{#each SECTION_ORDER as name (name)}
@@ -263,13 +268,15 @@
 												<button
 													class="secondary shrink-0 px-2 py-0.5 text-xs"
 													onclick={() => toggleMenu(key)}
-													aria-label="Insert into resume">+</button
+													aria-label="Add this to your resume"
+													title="Add this to your resume">+ Add</button
 												>
 											</div>
 											{#if menuFor === key}
 												<OnetInsertMenu
+													heading="Add as a bullet point to:"
 													targets={bulletDests}
-													emptyMessage="Add an experience or project first."
+													emptyMessage="Add an experience or project on the Experience or Projects tab first, then come back."
 													onPick={(id) => {
 														const target = bulletDests.find((t) => t.id === id)!;
 														insertBullet(target.kind, id, item.text);
@@ -297,11 +304,13 @@
 															<button
 																class="secondary shrink-0 px-2 py-0.5 text-xs"
 																onclick={() => toggleMenu(key)}
-																aria-label="Insert into resume">+</button
+																aria-label="Add this to your resume"
+																title="Add this to your resume">+ Add</button
 															>
 														</div>
 														{#if menuFor === key}
 															<OnetInsertMenu
+																heading="Add to skill category:"
 																targets={skillDests}
 																allowNew
 																onPick={(id) => insertSkill(id, example.name)}
@@ -325,11 +334,13 @@
 												<button
 													class="secondary shrink-0 px-2 py-0.5 text-xs"
 													onclick={() => toggleMenu(key)}
-													aria-label="Insert into resume">+</button
+													aria-label="Add this to your resume"
+													title="Add this to your resume">+ Add</button
 												>
 											</div>
 											{#if menuFor === key}
 												<OnetInsertMenu
+													heading="Add to skill category:"
 													targets={skillDests}
 													allowNew
 													onPick={(id) => insertSkill(id, element.name)}

--- a/web/src/lib/components/OnetInsertMenu.svelte
+++ b/web/src/lib/components/OnetInsertMenu.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	// Expands inline beneath the item being inserted. Inline rather than a floating
+	// popover so it can't be clipped by the drawer's scroll container.
+	let {
+		targets,
+		allowNew = false,
+		newPlaceholder = 'New category name',
+		emptyMessage = 'Nothing to insert into yet.',
+		onPick,
+		onCreate,
+	}: {
+		targets: { id: string; label: string }[];
+		allowNew?: boolean;
+		newPlaceholder?: string;
+		emptyMessage?: string;
+		onPick: (id: string) => void;
+		onCreate?: (name: string) => void;
+	} = $props();
+
+	let newName = $state('');
+
+	function create() {
+		const name = newName.trim();
+		if (!name || !onCreate) return;
+		onCreate(name);
+		newName = '';
+	}
+</script>
+
+<div class="mt-2 rounded border border-gray-300 bg-gray-50 p-2 space-y-1">
+	<p class="text-xs font-medium text-gray-600 px-1">Insert into</p>
+
+	{#each targets as target (target.id)}
+		<button
+			class="block w-full text-left text-xs font-normal px-2 py-1 rounded bg-white border border-gray-200 hover:bg-blue-50 hover:border-blue-300"
+			onclick={() => onPick(target.id)}
+		>
+			{target.label}
+		</button>
+	{/each}
+
+	{#if targets.length === 0 && !allowNew}
+		<p class="text-xs text-gray-500 px-1 py-1">{emptyMessage}</p>
+	{/if}
+
+	{#if allowNew}
+		<div class="flex gap-1 pt-1">
+			<input
+				type="text"
+				bind:value={newName}
+				placeholder={newPlaceholder}
+				class="text-xs !py-1"
+				onkeydown={(e) => e.key === 'Enter' && create()}
+			/>
+			<button class="primary text-xs px-2 py-1 shrink-0" onclick={create} disabled={!newName.trim()}>Create</button>
+		</div>
+	{/if}
+</div>

--- a/web/src/lib/components/OnetInsertMenu.svelte
+++ b/web/src/lib/components/OnetInsertMenu.svelte
@@ -2,6 +2,7 @@
 	// Expands inline beneath the item being inserted. Inline rather than a floating
 	// popover so it can't be clipped by the drawer's scroll container.
 	let {
+		heading,
 		targets,
 		allowNew = false,
 		newPlaceholder = 'New category name',
@@ -9,6 +10,8 @@
 		onPick,
 		onCreate,
 	}: {
+		// Says what the pick will actually do, e.g. "Add as a bullet point to:".
+		heading: string;
 		targets: { id: string; label: string }[];
 		allowNew?: boolean;
 		newPlaceholder?: string;
@@ -28,7 +31,7 @@
 </script>
 
 <div class="mt-2 rounded border border-gray-300 bg-gray-50 p-2 space-y-1">
-	<p class="text-xs font-medium text-gray-600 px-1">Insert into</p>
+	<p class="text-xs font-medium text-gray-600 px-1">{heading}</p>
 
 	{#each targets as target (target.id)}
 		<button

--- a/web/src/lib/components/PreviewPanel.svelte
+++ b/web/src/lib/components/PreviewPanel.svelte
@@ -16,7 +16,9 @@
 	}
 </script>
 
-<div class="bg-gray-500 rounded-lg shadow p-4 flex flex-col items-center overflow-auto max-h-[calc(100vh-10rem)]">
+<div
+	class="bg-gray-500 rounded-lg shadow p-4 flex flex-col items-center overflow-auto max-h-[calc(100vh-10rem)] lg:max-h-none lg:h-full"
+>
 	<h2 class="text-lg font-semibold mb-4 text-white">
 		{showCode ? 'Typst Code' : 'Resume Preview (8.5" x 11")'}
 	</h2>

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { applyTailorEdits } from './onet-apply';
+import { defaultResumeData } from './types';
+import type { ResumeData } from './types';
+import type { TailorEdit } from './onet-types';
+
+function seed(): ResumeData {
+	return {
+		...structuredClone(defaultResumeData),
+		workExperience: [
+			{
+				id: 'w1',
+				title: 'Software Engineer',
+				company: 'Acme',
+				location: '',
+				startDate: '',
+				endDate: '',
+				isPresent: true,
+				bullets: ['Built an API.'],
+			},
+		],
+		projects: [{ id: 'p1', name: 'Resume Builder', stack: '', url: '', award: '', bullets: [] }],
+		skills: [{ id: 's1', category: 'Languages', skills: 'Python' }],
+	};
+}
+
+const bullet = (targetId: string, text: string): TailorEdit => ({ kind: 'bullet', targetId, text });
+const skill = (targetId: string, text: string): TailorEdit => ({ kind: 'skill', targetId, text });
+
+describe('applyTailorEdits', () => {
+	it('appends a bullet to the named experience entry', () => {
+		const { data, paths } = applyTailorEdits(seed(), [bullet('w1', 'Modified existing software.')]);
+
+		expect(data.workExperience[0].bullets).toEqual(['Built an API.', 'Modified existing software.']);
+		expect(paths).toEqual(['workExperience.0.bullets.1']);
+	});
+
+	it('routes a bullet to a project when the id is a project', () => {
+		const { data, paths } = applyTailorEdits(seed(), [bullet('p1', 'Tested performance.')]);
+
+		expect(data.projects[0].bullets).toEqual(['Tested performance.']);
+		expect(paths).toEqual(['projects.0.bullets.0']);
+	});
+
+	it('appends a skill to the named category', () => {
+		const { data, paths } = applyTailorEdits(seed(), [skill('s1', 'Go')]);
+
+		expect(data.skills[0].skills).toBe('Python, Go');
+		expect(paths).toEqual(['skills.0.skills']);
+	});
+
+	it('applies several edits across different entries in one pass', () => {
+		const { data, paths } = applyTailorEdits(seed(), [
+			bullet('w1', 'First added bullet.'),
+			bullet('w1', 'Second added bullet.'),
+			bullet('p1', 'Project bullet.'),
+			skill('s1', 'Rust'),
+		]);
+
+		expect(data.workExperience[0].bullets).toEqual(['Built an API.', 'First added bullet.', 'Second added bullet.']);
+		expect(data.projects[0].bullets).toEqual(['Project bullet.']);
+		expect(data.skills[0].skills).toBe('Python, Rust');
+		// Every applied edit reports a distinct highlight path.
+		expect(new Set(paths).size).toBe(4);
+	});
+
+	it('reports the right index for the second bullet added to one entry', () => {
+		const { paths } = applyTailorEdits(seed(), [bullet('w1', 'One.'), bullet('w1', 'Two.')]);
+		expect(paths).toEqual(['workExperience.0.bullets.1', 'workExperience.0.bullets.2']);
+	});
+
+	it('skips an edit whose target no longer exists without dropping the rest', () => {
+		const { data, paths } = applyTailorEdits(seed(), [bullet('ghost', 'Orphan.'), bullet('w1', 'Kept.')]);
+
+		expect(data.workExperience[0].bullets).toEqual(['Built an API.', 'Kept.']);
+		expect(paths).toEqual(['workExperience.0.bullets.1']);
+	});
+
+	it('skips a duplicate the resume already contains', () => {
+		const { data, paths } = applyTailorEdits(seed(), [bullet('w1', 'Built an API.')]);
+
+		expect(data.workExperience[0].bullets).toEqual(['Built an API.']);
+		expect(paths).toEqual([]);
+	});
+
+	it('leaves the resume untouched when there is nothing to apply', () => {
+		const before = seed();
+		const { data, paths } = applyTailorEdits(before, []);
+
+		expect(data).toEqual(before);
+		expect(paths).toEqual([]);
+	});
+});

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -1,0 +1,32 @@
+import type { ResumeData } from './types';
+import type { TailorEdit } from './onet-types';
+import { appendBullet, appendSkill, bulletTargets } from './onet-insert';
+
+// Apply a batch of AI-proposed edits in order, reusing the same append helpers
+// the manual "+ Add" buttons use so both paths behave identically (including
+// duplicate suppression). Returns the new resume and the dotted paths to
+// highlight. An edit whose target has since disappeared is skipped rather than
+// aborting the batch.
+export function applyTailorEdits(data: ResumeData, edits: TailorEdit[]): { data: ResumeData; paths: string[] } {
+	let next = data;
+	const paths: string[] = [];
+
+	for (const edit of edits) {
+		if (edit.kind === 'skill') {
+			const result = appendSkill(next, edit.targetId, edit.text);
+			next = result.data;
+			if (result.path) paths.push(result.path);
+			continue;
+		}
+
+		// Look the kind up fresh each time: earlier edits can change the arrays.
+		const target = bulletTargets(next).find((t) => t.id === edit.targetId);
+		if (!target) continue;
+
+		const result = appendBullet(next, target.kind, edit.targetId, edit.text);
+		next = result.data;
+		if (result.path) paths.push(result.path);
+	}
+
+	return { data: next, paths };
+}

--- a/web/src/lib/onet-insert.test.ts
+++ b/web/src/lib/onet-insert.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { appendBullet, appendSkill, appendSkillToNewCategory, bulletTargets, skillTargets } from './onet-insert';
+import { defaultResumeData } from './types';
+import type { ResumeData } from './types';
+
+function seed(): ResumeData {
+	return {
+		...structuredClone(defaultResumeData),
+		workExperience: [
+			{
+				id: 'w1',
+				title: 'Software Engineer',
+				company: 'Acme',
+				location: '',
+				startDate: '',
+				endDate: '',
+				isPresent: true,
+				bullets: ['Shipped the thing.'],
+			},
+			{
+				id: 'w2',
+				title: 'Intern',
+				company: 'Foo',
+				location: '',
+				startDate: '',
+				endDate: '',
+				isPresent: false,
+				bullets: [],
+			},
+		],
+		projects: [{ id: 'p1', name: 'Resume Builder', stack: '', url: '', award: '', bullets: [] }],
+		skills: [
+			{ id: 's1', category: 'Languages', skills: 'Python, TypeScript' },
+			{ id: 's2', category: 'Tools', skills: '' },
+		],
+	};
+}
+
+describe('bulletTargets', () => {
+	it('lists work experience and projects with labels a user can tell apart', () => {
+		expect(bulletTargets(seed())).toEqual([
+			{ id: 'w1', kind: 'experience', label: 'Software Engineer at Acme' },
+			{ id: 'w2', kind: 'experience', label: 'Intern at Foo' },
+			{ id: 'p1', kind: 'project', label: 'Resume Builder' },
+		]);
+	});
+
+	it('falls back to a placeholder label for an unnamed entry', () => {
+		const data = seed();
+		data.workExperience[0].title = '';
+		data.workExperience[0].company = '';
+		expect(bulletTargets(data)[0].label).toBe('Untitled experience');
+	});
+
+	it('returns nothing when the resume has no entries to insert into', () => {
+		expect(bulletTargets(structuredClone(defaultResumeData))).toEqual([]);
+	});
+});
+
+describe('skillTargets', () => {
+	it('lists existing skill categories', () => {
+		expect(skillTargets(seed())).toEqual([
+			{ id: 's1', label: 'Languages' },
+			{ id: 's2', label: 'Tools' },
+		]);
+	});
+});
+
+describe('appendBullet', () => {
+	it('appends to the chosen experience entry and reports its highlight path', () => {
+		const { data, path } = appendBullet(seed(), 'experience', 'w1', 'Modify existing software.');
+
+		expect(data.workExperience[0].bullets).toEqual(['Shipped the thing.', 'Modify existing software.']);
+		expect(path).toBe('workExperience.0.bullets.1');
+	});
+
+	it('appends to a project rather than an experience when asked', () => {
+		const { data, path } = appendBullet(seed(), 'project', 'p1', 'Test software performance.');
+
+		expect(data.projects[0].bullets).toEqual(['Test software performance.']);
+		expect(path).toBe('projects.0.bullets.0');
+	});
+
+	it('leaves every other entry untouched', () => {
+		const before = seed();
+		const { data } = appendBullet(before, 'experience', 'w1', 'New bullet.');
+
+		expect(data.workExperience[1]).toEqual(before.workExperience[1]);
+		expect(data.projects).toEqual(before.projects);
+		expect(data.skills).toEqual(before.skills);
+	});
+
+	it('does not duplicate a bullet that is already on the entry', () => {
+		const { data, path } = appendBullet(seed(), 'experience', 'w1', 'Shipped the thing.');
+
+		expect(data.workExperience[0].bullets).toEqual(['Shipped the thing.']);
+		expect(path).toBeNull();
+	});
+
+	it('returns the resume unchanged when the target id is unknown', () => {
+		const before = seed();
+		const { data, path } = appendBullet(before, 'experience', 'nope', 'Orphan bullet.');
+
+		expect(data).toEqual(before);
+		expect(path).toBeNull();
+	});
+});
+
+describe('appendSkill', () => {
+	it('appends to a comma-separated category', () => {
+		const { data, path } = appendSkill(seed(), 's1', 'Git');
+
+		expect(data.skills[0].skills).toBe('Python, TypeScript, Git');
+		expect(path).toBe('skills.0.skills');
+	});
+
+	it('does not leave a leading comma when the category was empty', () => {
+		const { data } = appendSkill(seed(), 's2', 'Docker');
+		expect(data.skills[1].skills).toBe('Docker');
+	});
+
+	it('ignores a skill already listed in that category, case-insensitively', () => {
+		const { data, path } = appendSkill(seed(), 's1', 'python');
+
+		expect(data.skills[0].skills).toBe('Python, TypeScript');
+		expect(path).toBeNull();
+	});
+
+	it('returns the resume unchanged when the category id is unknown', () => {
+		const before = seed();
+		const { data, path } = appendSkill(before, 'nope', 'Git');
+
+		expect(data).toEqual(before);
+		expect(path).toBeNull();
+	});
+});
+
+describe('appendSkillToNewCategory', () => {
+	it('creates the category with the skill in it and highlights both fields', () => {
+		const { data, paths } = appendSkillToNewCategory(seed(), 'Cloud', 'Kubernetes');
+
+		expect(data.skills).toHaveLength(3);
+		expect(data.skills[2]).toMatchObject({ category: 'Cloud', skills: 'Kubernetes' });
+		expect(data.skills[2].id).toBeTruthy();
+		expect(paths).toEqual(['skills.2.category', 'skills.2.skills']);
+	});
+
+	it('leaves existing categories untouched', () => {
+		const before = seed();
+		const { data } = appendSkillToNewCategory(before, 'Cloud', 'Kubernetes');
+		expect(data.skills.slice(0, 2)).toEqual(before.skills);
+	});
+});

--- a/web/src/lib/onet-insert.ts
+++ b/web/src/lib/onet-insert.ts
@@ -1,0 +1,97 @@
+import type { ResumeData } from './types';
+import { generateId } from './resume-utils';
+
+// Pulling an O*NET item into the resume. These are pure: they return a new
+// ResumeData plus the dotted field path(s) to highlight, and the caller assigns
+// the result. A null path means nothing changed.
+
+export type BulletTargetKind = 'experience' | 'project';
+
+export interface BulletTarget {
+	id: string;
+	kind: BulletTargetKind;
+	label: string;
+}
+
+export interface SkillTarget {
+	id: string;
+	label: string;
+}
+
+export function bulletTargets(data: ResumeData): BulletTarget[] {
+	const experience = data.workExperience.map((w) => ({
+		id: w.id,
+		kind: 'experience' as const,
+		label: [w.title, w.company].filter(Boolean).join(' at ') || 'Untitled experience',
+	}));
+	const projects = data.projects.map((p) => ({
+		id: p.id,
+		kind: 'project' as const,
+		label: p.name || 'Untitled project',
+	}));
+	return [...experience, ...projects];
+}
+
+export function skillTargets(data: ResumeData): SkillTarget[] {
+	return data.skills.map((s) => ({ id: s.id, label: s.category || 'Untitled category' }));
+}
+
+export function appendBullet(
+	data: ResumeData,
+	kind: BulletTargetKind,
+	id: string,
+	text: string,
+): { data: ResumeData; path: string | null } {
+	const key = kind === 'experience' ? 'workExperience' : 'projects';
+	const entries = data[key];
+	const index = entries.findIndex((e) => e.id === id);
+	if (index === -1) return { data, path: null };
+
+	const entry = entries[index];
+	if (entry.bullets.includes(text)) return { data, path: null };
+
+	const updated = [...entries];
+	updated[index] = { ...entry, bullets: [...entry.bullets, text] };
+
+	return {
+		data: { ...data, [key]: updated },
+		path: `${key}.${index}.bullets.${entry.bullets.length}`,
+	};
+}
+
+// Skill categories store their skills as one comma-separated string.
+function listed(skills: string): string[] {
+	return skills
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+export function appendSkill(
+	data: ResumeData,
+	categoryId: string,
+	name: string,
+): { data: ResumeData; path: string | null } {
+	const index = data.skills.findIndex((s) => s.id === categoryId);
+	if (index === -1) return { data, path: null };
+
+	const category = data.skills[index];
+	const existing = listed(category.skills);
+	if (existing.some((s) => s.toLowerCase() === name.toLowerCase())) return { data, path: null };
+
+	const updated = [...data.skills];
+	updated[index] = { ...category, skills: [...existing, name].join(', ') };
+
+	return { data: { ...data, skills: updated }, path: `skills.${index}.skills` };
+}
+
+export function appendSkillToNewCategory(
+	data: ResumeData,
+	category: string,
+	name: string,
+): { data: ResumeData; paths: string[] } {
+	const index = data.skills.length;
+	const skills = [...data.skills, { id: generateId(), category, skills: name }];
+
+	return { data: { ...data, skills }, paths: [`skills.${index}.category`, `skills.${index}.skills`] };
+}

--- a/web/src/lib/onet-store.test.ts
+++ b/web/src/lib/onet-store.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { onetStore, ONET_STORAGE_KEY } from './onet-store';
+
+function fakeStorage() {
+	const map = new Map<string, string>();
+	return {
+		getItem: (k: string) => map.get(k) ?? null,
+		setItem: (k: string, v: string) => void map.set(k, v),
+		removeItem: (k: string) => void map.delete(k),
+		clear: () => map.clear(),
+		key: () => null,
+		length: 0,
+	} as unknown as Storage;
+}
+
+beforeEach(() => {
+	onetStore.clear();
+	vi.stubGlobal('localStorage', fakeStorage());
+});
+
+const REF = { code: '15-1252.00', title: 'Software Developers', brightOutlook: true };
+
+describe('onetStore', () => {
+	it('starts with no occupation selected', () => {
+		expect(get(onetStore)).toBeNull();
+	});
+
+	it('round-trips a selection through storage', () => {
+		onetStore.select(REF);
+		onetStore.saveToStorage();
+
+		onetStore.clear();
+		expect(get(onetStore)).toBeNull();
+
+		onetStore.loadFromStorage();
+		expect(get(onetStore)).toEqual(REF);
+	});
+
+	it('persists under its own key, leaving resume data untouched', () => {
+		localStorage.setItem('resumeData', '{"personalInfo":{"name":"Ada"}}');
+		onetStore.select(REF);
+		onetStore.saveToStorage();
+
+		expect(localStorage.getItem('resumeData')).toBe('{"personalInfo":{"name":"Ada"}}');
+		expect(JSON.parse(localStorage.getItem(ONET_STORAGE_KEY)!)).toEqual(REF);
+	});
+
+	it('clearing a selection removes it from storage', () => {
+		onetStore.select(REF);
+		onetStore.saveToStorage();
+
+		onetStore.clear();
+		onetStore.saveToStorage();
+
+		onetStore.loadFromStorage();
+		expect(get(onetStore)).toBeNull();
+	});
+
+	it('ignores corrupt stored JSON rather than throwing', () => {
+		localStorage.setItem(ONET_STORAGE_KEY, '{not json');
+		expect(() => onetStore.loadFromStorage()).not.toThrow();
+		expect(get(onetStore)).toBeNull();
+	});
+
+	it('ignores stored data that is missing a code', () => {
+		localStorage.setItem(ONET_STORAGE_KEY, JSON.stringify({ title: 'Orphan' }));
+		onetStore.loadFromStorage();
+		expect(get(onetStore)).toBeNull();
+	});
+});

--- a/web/src/lib/onet-store.ts
+++ b/web/src/lib/onet-store.ts
@@ -1,0 +1,40 @@
+import { writable, get } from 'svelte/store';
+import type { OnetOccupationRef } from './onet-types';
+
+// Deliberately separate from resumeStore: the target occupation is reference
+// state, not resume content, so it must never reach ResumeData or the PDF.
+export const ONET_STORAGE_KEY = 'onetSelection';
+
+function isRef(value: unknown): value is OnetOccupationRef {
+	const v = value as Record<string, unknown> | null;
+	return !!v && typeof v.code === 'string' && v.code !== '' && typeof v.title === 'string';
+}
+
+function createOnetStore() {
+	const { subscribe, set } = writable<OnetOccupationRef | null>(null);
+
+	return {
+		subscribe,
+		select: (ref: OnetOccupationRef) => set(ref),
+		clear: () => set(null),
+		loadFromStorage: () => {
+			if (typeof localStorage === 'undefined') return;
+			const saved = localStorage.getItem(ONET_STORAGE_KEY);
+			if (!saved) return;
+			try {
+				const parsed = JSON.parse(saved);
+				if (isRef(parsed)) set({ ...parsed, brightOutlook: parsed.brightOutlook === true });
+			} catch {
+				// Corrupt entry from an older version; fall back to no selection.
+			}
+		},
+		saveToStorage: () => {
+			if (typeof localStorage === 'undefined') return;
+			const current = get({ subscribe });
+			if (current) localStorage.setItem(ONET_STORAGE_KEY, JSON.stringify(current));
+			else localStorage.removeItem(ONET_STORAGE_KEY);
+		},
+	};
+}
+
+export const onetStore = createOnetStore();

--- a/web/src/lib/onet-types.ts
+++ b/web/src/lib/onet-types.ts
@@ -1,0 +1,59 @@
+// Types for O*NET Web Services data. Kept separate from types.ts, which models
+// the resume itself — a target occupation is reference data and never renders.
+
+export interface OnetOccupationRef {
+	code: string;
+	title: string;
+	brightOutlook: boolean;
+}
+
+// Tasks and detailed work activities: a single line of prose.
+export interface OnetItem {
+	id: string;
+	text: string;
+}
+
+// Skills, knowledge, abilities: a named competency with a definition.
+export interface OnetScaleItem {
+	id: string;
+	name: string;
+	description: string;
+}
+
+export interface OnetTechnology {
+	category: string;
+	examples: { name: string; hot: boolean }[];
+}
+
+export type OnetSectionName =
+	| 'tasks'
+	| 'detailedWorkActivities'
+	| 'technologySkills'
+	| 'skills'
+	| 'knowledge'
+	| 'abilities';
+
+export interface OnetOccupation {
+	code: string;
+	title: string;
+	description: string;
+	brightOutlook: boolean;
+	tasks: OnetItem[];
+	detailedWorkActivities: OnetItem[];
+	technologySkills: OnetTechnology[];
+	skills: OnetScaleItem[];
+	knowledge: OnetScaleItem[];
+	abilities: OnetScaleItem[];
+	// Sections O*NET does not publish for this occupation. Rendered as
+	// "not published" rather than as an empty list, so the two are distinguishable.
+	unavailable: OnetSectionName[];
+}
+
+export const onetSectionLabels: Record<OnetSectionName, string> = {
+	tasks: 'Tasks',
+	detailedWorkActivities: 'Work Activities',
+	technologySkills: 'Technology',
+	skills: 'Skills',
+	knowledge: 'Knowledge',
+	abilities: 'Abilities',
+};

--- a/web/src/lib/onet-types.ts
+++ b/web/src/lib/onet-types.ts
@@ -57,3 +57,11 @@ export const onetSectionLabels: Record<OnetSectionName, string> = {
 	knowledge: 'Knowledge',
 	abilities: 'Abilities',
 };
+
+// One change proposed by the AI tailor pass. `targetId` is the id of a work
+// experience / project entry (kind 'bullet') or a skill category (kind 'skill').
+export interface TailorEdit {
+	kind: 'bullet' | 'skill';
+	targetId: string;
+	text: string;
+}

--- a/web/src/lib/server/onet-route.ts
+++ b/web/src/lib/server/onet-route.ts
@@ -1,0 +1,30 @@
+import { json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { onetError, type OnetError } from './onet';
+
+// O*NET publishes on an annual cadence, so a one-week edge TTL is safe. Vercel's
+// CDN honours s-maxage and stale-while-revalidate on every plan, including Hobby,
+// which is what keeps this feature inside the free tier.
+export const ONET_CACHE_CONTROL = 'public, max-age=0, s-maxage=604800, stale-while-revalidate=86400';
+
+// Read at request time rather than through $env/static/private: a missing key
+// should surface as a runtime auth error, not break the build.
+export function onetKey(): string {
+	return env.ONET_API_KEY ?? '';
+}
+
+function isOnetError(e: unknown): e is OnetError {
+	const v = e as Record<string, unknown> | null;
+	return !!v && typeof v.code === 'string' && typeof v.status === 'number' && typeof v.message === 'string';
+}
+
+// Match the { error: { code, message } } shape /api/extract already returns, so
+// the client renders failures from either endpoint the same way.
+export function onetFail(e: unknown): Response {
+	const err = isOnetError(e) ? e : onetError('unknown');
+	return json({ error: { code: err.code, message: err.message } }, { status: err.status });
+}
+
+export function onetOk(body: unknown): Response {
+	return json(body, { headers: { 'Cache-Control': ONET_CACHE_CONTROL } });
+}

--- a/web/src/lib/server/onet.test.ts
+++ b/web/src/lib/server/onet.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+	isValidOnetCode,
+	normalizeSearch,
+	normalizeItems,
+	normalizeActivities,
+	normalizeElements,
+	normalizeTechnology,
+	mapOnetError,
+	onetError,
+	searchOccupations,
+	fetchOccupation,
+} from './onet';
+
+const KEY = 'test-key';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+// Build a fetch stub that answers by pathname suffix. Matching on the pathname
+// rather than the whole URL keeps the overview route (which is a prefix of every
+// section route) from swallowing section requests. Anything unmatched returns
+// 422, which is what O*NET does for a section it doesn't publish.
+function stubFetch(routes: Record<string, { status?: number; body?: unknown }>) {
+	const calls: string[] = [];
+	const fn = vi.fn(async (url: string, init?: RequestInit) => {
+		calls.push(url);
+		const { pathname } = new URL(url);
+		const hit = Object.entries(routes).find(([frag]) => pathname.endsWith(frag));
+		if (!hit) return new Response('nope', { status: 422 });
+		const [, res] = hit;
+		const status = res.status ?? 200;
+		if (status >= 400) return new Response('err', { status });
+		return new Response(JSON.stringify(res.body), {
+			status,
+			headers: { 'content-type': 'application/json' },
+		});
+	});
+	vi.stubGlobal('fetch', fn);
+	return { fn, calls };
+}
+
+describe('isValidOnetCode', () => {
+	it('accepts a well-formed O*NET-SOC code', () => {
+		expect(isValidOnetCode('15-1252.00')).toBe(true);
+	});
+
+	it.each([
+		['../../etc/passwd', 'path traversal'],
+		['15-1252.00/../../admin', 'traversal suffix'],
+		['15-1252.00?key=leak', 'query injection'],
+		['15-1252', 'missing detail suffix'],
+		['5-1252.00', 'too few major digits'],
+		['15-1252.000', 'too many detail digits'],
+		['', 'empty'],
+	])('rejects %s (%s)', (code) => {
+		expect(isValidOnetCode(code)).toBe(false);
+	});
+});
+
+describe('normalizeSearch', () => {
+	it('maps occupation results and defaults bright_outlook to false', () => {
+		const raw = {
+			total: 2,
+			occupation: [
+				{ href: 'x', code: '15-1252.00', title: 'Software Developers', tags: { bright_outlook: true } },
+				{ href: 'y', code: '15-1253.00', title: 'Software QA Analysts', tags: {} },
+			],
+		};
+		expect(normalizeSearch(raw)).toEqual([
+			{ code: '15-1252.00', title: 'Software Developers', brightOutlook: true },
+			{ code: '15-1253.00', title: 'Software QA Analysts', brightOutlook: false },
+		]);
+	});
+
+	it('returns an empty array when O*NET omits the occupation key', () => {
+		expect(normalizeSearch({ total: 0 })).toEqual([]);
+	});
+});
+
+describe('normalizeItems (tasks)', () => {
+	it('reads task text from the title field', () => {
+		const raw = { task: [{ id: '1', related: 'r', title: 'Modify existing software to correct errors.' }] };
+		expect(normalizeItems(raw)).toEqual([{ id: '1', text: 'Modify existing software to correct errors.' }]);
+	});
+
+	it('returns an empty array when the task key is absent', () => {
+		expect(normalizeItems({})).toEqual([]);
+	});
+});
+
+describe('normalizeActivities', () => {
+	it('reads activities from the activity key, not the task key', () => {
+		const raw = { activity: [{ id: '4.A.3.b.1', title: 'Test software performance.', related: 'r' }] };
+		expect(normalizeActivities(raw)).toEqual([{ id: '4.A.3.b.1', text: 'Test software performance.' }]);
+	});
+});
+
+describe('normalizeElements (skills / knowledge / abilities)', () => {
+	it('keeps the competency name and its definition separate', () => {
+		const raw = {
+			element: [{ id: '2.B.3.e', related: 'r', name: 'Programming', description: 'Writing computer programs.' }],
+		};
+		expect(normalizeElements(raw)).toEqual([
+			{ id: '2.B.3.e', name: 'Programming', description: 'Writing computer programs.' },
+		]);
+	});
+});
+
+describe('normalizeTechnology', () => {
+	it('flattens example and example_more into one list and carries the hot flag', () => {
+		const raw = {
+			category: [
+				{
+					code: 43232408,
+					related: 'r',
+					title: 'Development environment software',
+					example: [{ title: 'Apache Kafka', href: 'a', hot_technology: true }],
+					example_more: [{ title: 'Oracle Java', href: 'b' }],
+				},
+			],
+		};
+		expect(normalizeTechnology(raw)).toEqual([
+			{
+				category: 'Development environment software',
+				examples: [
+					{ name: 'Apache Kafka', hot: true },
+					{ name: 'Oracle Java', hot: false },
+				],
+			},
+		]);
+	});
+
+	it('tolerates a category with no examples', () => {
+		const raw = { category: [{ code: 1, related: 'r', title: 'Empty category' }] };
+		expect(normalizeTechnology(raw)).toEqual([{ category: 'Empty category', examples: [] }]);
+	});
+});
+
+describe('mapOnetError', () => {
+	it.each([
+		[401, 'auth'],
+		[403, 'auth'],
+		[422, 'not_found'],
+		[404, 'not_found'],
+		[429, 'rate_limited'],
+		[500, 'upstream_unavailable'],
+		[503, 'upstream_unavailable'],
+	])('maps HTTP %i to %s', (status, code) => {
+		expect(mapOnetError({ status }).code).toBe(code);
+	});
+
+	it('maps a network failure with no status to upstream_unavailable', () => {
+		expect(mapOnetError(new TypeError('fetch failed')).code).toBe('upstream_unavailable');
+	});
+});
+
+describe('searchOccupations', () => {
+	it('sends the key as a header and never in the query string', async () => {
+		const { fn } = stubFetch({ '/online/search': { body: { total: 0, occupation: [] } } });
+		await searchOccupations('software', KEY);
+
+		const [url, init] = fn.mock.calls[0] as [string, RequestInit];
+		expect(url).not.toContain(KEY);
+		expect((init.headers as Record<string, string>)['X-API-Key']).toBe(KEY);
+	});
+
+	it('url-encodes the keyword', async () => {
+		const { fn } = stubFetch({ '/online/search': { body: { total: 0, occupation: [] } } });
+		await searchOccupations('a&b=c d', KEY);
+		expect(fn.mock.calls[0][0]).toContain('keyword=a%26b%3Dc+d');
+	});
+
+	it('throws a mapped auth error when the key is rejected', async () => {
+		stubFetch({ '/online/search': { status: 401 } });
+		await expect(searchOccupations('software', KEY)).rejects.toMatchObject({ code: 'auth' });
+	});
+});
+
+describe('fetchOccupation', () => {
+	const overview = {
+		code: '15-1252.00',
+		title: 'Software Developers',
+		description: 'Research and design software systems.',
+		tags: { bright_outlook: true },
+	};
+	const full = {
+		'/summary/tasks': { body: { task: [{ id: '1', related: 'r', title: 'Modify software.' }] } },
+		'/summary/detailed_work_activities': {
+			body: { activity: [{ id: '2', title: 'Test software performance.', related: 'r' }] },
+		},
+		'/summary/technology_skills': {
+			body: { category: [{ code: 1, related: 'r', title: 'IDEs', example: [{ title: 'Git', href: 'g' }] }] },
+		},
+		'/summary/skills': { body: { element: [{ id: 's', related: 'r', name: 'Programming', description: 'd' }] } },
+		'/summary/knowledge': { body: { element: [{ id: 'k', related: 'r', name: 'Engineering', description: 'd' }] } },
+		'/summary/abilities': { body: { element: [{ id: 'a', related: 'r', name: 'Deductive', description: 'd' }] } },
+		'/online/occupations/15-1252.00/': { body: overview },
+	};
+
+	it('merges every section into one payload', async () => {
+		stubFetch(full);
+		const occ = await fetchOccupation('15-1252.00', KEY);
+
+		expect(occ.title).toBe('Software Developers');
+		expect(occ.description).toBe('Research and design software systems.');
+		expect(occ.brightOutlook).toBe(true);
+		expect(occ.tasks).toHaveLength(1);
+		expect(occ.detailedWorkActivities[0].text).toBe('Test software performance.');
+		expect(occ.technologySkills[0].examples[0].name).toBe('Git');
+		expect(occ.skills[0].name).toBe('Programming');
+		expect(occ.unavailable).toEqual([]);
+	});
+
+	it('degrades a section O*NET does not publish instead of failing the request', async () => {
+		const { '/summary/abilities': _dropped, ...withoutAbilities } = full;
+		stubFetch(withoutAbilities);
+
+		const occ = await fetchOccupation('15-1252.00', KEY);
+
+		expect(occ.abilities).toEqual([]);
+		expect(occ.unavailable).toContain('abilities');
+		expect(occ.tasks).toHaveLength(1); // the rest still came through
+	});
+
+	it('fails the whole request when the overview itself is unavailable', async () => {
+		stubFetch({ '/summary/tasks': full['/summary/tasks'] });
+		await expect(fetchOccupation('15-1252.00', KEY)).rejects.toMatchObject({ code: 'not_found' });
+	});
+
+	it('rejects an invalid code before making any request', async () => {
+		const { fn } = stubFetch(full);
+		await expect(fetchOccupation('../admin', KEY)).rejects.toMatchObject({ code: 'invalid_code' });
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it('fetches sections in parallel rather than serially', async () => {
+		stubFetch(full);
+		await fetchOccupation('15-1252.00', KEY);
+		// overview + six sections
+		expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(7);
+	});
+});
+
+describe('onetError', () => {
+	it('carries a user-facing message and an HTTP status', () => {
+		const e = onetError('rate_limited');
+		expect(e.status).toBe(429);
+		expect(e.message).toMatch(/busy/i);
+	});
+});

--- a/web/src/lib/server/onet.ts
+++ b/web/src/lib/server/onet.ts
@@ -1,0 +1,208 @@
+import type {
+	OnetItem,
+	OnetOccupation,
+	OnetOccupationRef,
+	OnetScaleItem,
+	OnetSectionName,
+	OnetTechnology,
+} from '$lib/onet-types';
+
+// O*NET Web Services v2. The key goes in a header; it cannot be a query param.
+const BASE = 'https://api-v2.onetcenter.org';
+
+// Sections are paginated with a default window of 20. Ask for the whole list.
+const PAGE_END = 100;
+
+export type OnetErrorCode = 'invalid_code' | 'not_found' | 'rate_limited' | 'auth' | 'upstream_unavailable' | 'unknown';
+
+export interface OnetError {
+	code: OnetErrorCode;
+	message: string;
+	status: number;
+}
+
+const MESSAGES: Record<OnetErrorCode, string> = {
+	invalid_code: "That job code isn't valid.",
+	not_found: 'No O*NET data for that occupation.',
+	rate_limited: 'O*NET is busy right now. Wait a moment and retry.',
+	auth: 'O*NET access is misconfigured (API key).',
+	upstream_unavailable: "Can't reach O*NET. Check your connection and retry.",
+	unknown: 'Something went wrong. Please try again.',
+};
+
+const STATUSES: Record<OnetErrorCode, number> = {
+	invalid_code: 400,
+	not_found: 404,
+	rate_limited: 429,
+	auth: 502,
+	upstream_unavailable: 502,
+	unknown: 500,
+};
+
+export function onetError(code: OnetErrorCode, status?: number): OnetError {
+	return { code, message: MESSAGES[code], status: status ?? STATUSES[code] };
+}
+
+// Map an upstream HTTP status (or a thrown network error) to our error shape.
+// O*NET answers 422 rather than 404 for an unknown code.
+export function mapOnetError(err: unknown): OnetError {
+	const status = (err as { status?: number })?.status;
+	if (status === 401 || status === 403) return onetError('auth');
+	if (status === 404 || status === 422) return onetError('not_found');
+	if (status === 429) return onetError('rate_limited');
+	if (typeof status === 'number' && status >= 500) return onetError('upstream_unavailable');
+	if (status === undefined) return onetError('upstream_unavailable'); // network / timeout
+	return onetError('unknown');
+}
+
+// O*NET-SOC codes look like 15-1252.00. Validate before putting one in a URL
+// path so a crafted code can't traverse or append a query.
+const CODE_RE = /^\d{2}-\d{4}\.\d{2}$/;
+
+export function isValidOnetCode(code: string): boolean {
+	return CODE_RE.test(code);
+}
+
+class HttpError extends Error {
+	constructor(readonly status: number) {
+		super(`O*NET responded ${status}`);
+	}
+}
+
+async function onetFetch(path: string, key: string): Promise<unknown> {
+	let res: Response;
+	try {
+		res = await fetch(`${BASE}${path}`, {
+			headers: { 'X-API-Key': key, Accept: 'application/json' },
+		});
+	} catch {
+		throw onetError('upstream_unavailable');
+	}
+	if (!res.ok) throw new HttpError(res.status);
+	try {
+		return await res.json();
+	} catch {
+		throw onetError('upstream_unavailable');
+	}
+}
+
+// --- Normalizers -----------------------------------------------------------
+// Each takes one raw O*NET payload. They are pure so they can be tested
+// against recorded shapes without a key or a network.
+
+type Raw = Record<string, unknown>;
+
+function arr(raw: unknown, key: string): Raw[] {
+	const v = (raw as Raw)?.[key];
+	return Array.isArray(v) ? (v as Raw[]) : [];
+}
+
+export function normalizeSearch(raw: unknown): OnetOccupationRef[] {
+	return arr(raw, 'occupation').map((o) => ({
+		code: String(o.code ?? ''),
+		title: String(o.title ?? ''),
+		brightOutlook: (o.tags as Raw)?.bright_outlook === true,
+	}));
+}
+
+// Tasks carry their prose in `title`.
+export function normalizeItems(raw: unknown): OnetItem[] {
+	return arr(raw, 'task').map((t) => ({ id: String(t.id ?? ''), text: String(t.title ?? '') }));
+}
+
+// Detailed work activities use `activity` rather than `task`.
+export function normalizeActivities(raw: unknown): OnetItem[] {
+	return arr(raw, 'activity').map((a) => ({ id: String(a.id ?? ''), text: String(a.title ?? '') }));
+}
+
+// Skills, knowledge and abilities all share the `element` shape.
+export function normalizeElements(raw: unknown): OnetScaleItem[] {
+	return arr(raw, 'element').map((e) => ({
+		id: String(e.id ?? ''),
+		name: String(e.name ?? ''),
+		description: String(e.description ?? ''),
+	}));
+}
+
+export function normalizeTechnology(raw: unknown): OnetTechnology[] {
+	return arr(raw, 'category').map((c) => {
+		const examples = [...arr(c, 'example'), ...arr(c, 'example_more')].map((e) => ({
+			name: String(e.title ?? ''),
+			hot: e.hot_technology === true,
+		}));
+		return { category: String(c.title ?? ''), examples };
+	});
+}
+
+// --- Requests --------------------------------------------------------------
+
+export async function searchOccupations(keyword: string, key: string): Promise<OnetOccupationRef[]> {
+	const qs = new URLSearchParams({ keyword, start: '1', end: '20' });
+	try {
+		return normalizeSearch(await onetFetch(`/online/search?${qs}`, key));
+	} catch (err) {
+		throw err instanceof HttpError ? mapOnetError(err) : err;
+	}
+}
+
+// A section that O*NET does not publish for this occupation resolves to null
+// rather than rejecting, so one missing section can't sink the whole report.
+async function section<T>(path: string, key: string, normalize: (raw: unknown) => T): Promise<T | null> {
+	try {
+		return normalize(await onetFetch(path, key));
+	} catch {
+		return null;
+	}
+}
+
+export async function fetchOccupation(code: string, key: string): Promise<OnetOccupation> {
+	if (!isValidOnetCode(code)) throw onetError('invalid_code');
+
+	const base = `/online/occupations/${code}`;
+	const page = `?start=1&end=${PAGE_END}`;
+
+	const overviewPromise = onetFetch(`${base}/`, key);
+	const sections = {
+		tasks: section(`${base}/summary/tasks${page}`, key, normalizeItems),
+		detailedWorkActivities: section(`${base}/summary/detailed_work_activities${page}`, key, normalizeActivities),
+		technologySkills: section(`${base}/summary/technology_skills${page}`, key, normalizeTechnology),
+		skills: section(`${base}/summary/skills${page}`, key, normalizeElements),
+		knowledge: section(`${base}/summary/knowledge${page}`, key, normalizeElements),
+		abilities: section(`${base}/summary/abilities${page}`, key, normalizeElements),
+	};
+
+	let overview: Raw;
+	try {
+		overview = (await overviewPromise) as Raw;
+	} catch (err) {
+		// Drain the section promises so a rejected overview doesn't leave them unhandled.
+		await Promise.allSettled(Object.values(sections));
+		throw err instanceof HttpError ? mapOnetError(err) : err;
+	}
+
+	const [tasks, detailedWorkActivities, technologySkills, skills, knowledge, abilities] = await Promise.all([
+		sections.tasks,
+		sections.detailedWorkActivities,
+		sections.technologySkills,
+		sections.skills,
+		sections.knowledge,
+		sections.abilities,
+	]);
+
+	const resolved = { tasks, detailedWorkActivities, technologySkills, skills, knowledge, abilities };
+	const unavailable = (Object.keys(resolved) as OnetSectionName[]).filter((name) => resolved[name] === null);
+
+	return {
+		code: String(overview.code ?? code),
+		title: String(overview.title ?? ''),
+		description: String(overview.description ?? ''),
+		brightOutlook: (overview.tags as Raw)?.bright_outlook === true,
+		tasks: tasks ?? [],
+		detailedWorkActivities: detailedWorkActivities ?? [],
+		technologySkills: technologySkills ?? [],
+		skills: skills ?? [],
+		knowledge: knowledge ?? [],
+		abilities: abilities ?? [],
+		unavailable,
+	};
+}

--- a/web/src/lib/server/tailor.test.ts
+++ b/web/src/lib/server/tailor.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { validateEdits, MAX_EDITS, buildTailorInput } from './tailor';
+import { defaultResumeData } from '$lib/types';
+import type { ResumeData } from '$lib/types';
+import type { OnetOccupation } from '$lib/onet-types';
+
+const allowed = { bullets: new Set(['w1', 'p1']), skills: new Set(['s1']) };
+
+function edit(over: Record<string, unknown> = {}) {
+	return { kind: 'bullet', targetId: 'w1', text: 'Shipped a thing.', ...over };
+}
+
+describe('validateEdits', () => {
+	it('keeps a well-formed edit', () => {
+		expect(validateEdits({ edits: [edit()] }, allowed)).toEqual([
+			{ kind: 'bullet', targetId: 'w1', text: 'Shipped a thing.' },
+		]);
+	});
+
+	// The model can invent an id that was never offered to it; those must not
+	// silently become inserts against the wrong entry (or none at all).
+	it('drops an edit whose target id was never offered', () => {
+		expect(validateEdits({ edits: [edit({ targetId: 'nope' })] }, allowed)).toEqual([]);
+	});
+
+	it('drops a bullet edit aimed at a skill category id', () => {
+		expect(validateEdits({ edits: [edit({ kind: 'bullet', targetId: 's1' })] }, allowed)).toEqual([]);
+	});
+
+	it('drops a skill edit aimed at an experience id', () => {
+		expect(validateEdits({ edits: [edit({ kind: 'skill', targetId: 'w1', text: 'Go' })] }, allowed)).toEqual([]);
+	});
+
+	it('drops an unknown kind', () => {
+		expect(validateEdits({ edits: [edit({ kind: 'profile' })] }, allowed)).toEqual([]);
+	});
+
+	it.each([[''], ['   '], [null], [42]])('drops an edit whose text is %p', (text) => {
+		expect(validateEdits({ edits: [edit({ text })] }, allowed)).toEqual([]);
+	});
+
+	it('trims surrounding whitespace from the text', () => {
+		expect(validateEdits({ edits: [edit({ text: '  Shipped a thing.  ' })] }, allowed)[0].text).toBe(
+			'Shipped a thing.',
+		);
+	});
+
+	it('drops duplicates of the same text on the same target', () => {
+		expect(validateEdits({ edits: [edit(), edit()] }, allowed)).toHaveLength(1);
+	});
+
+	it('keeps the same text on two different targets', () => {
+		expect(validateEdits({ edits: [edit(), edit({ targetId: 'p1' })] }, allowed)).toHaveLength(2);
+	});
+
+	it('caps runaway output at MAX_EDITS', () => {
+		const many = Array.from({ length: MAX_EDITS + 15 }, (_, i) => edit({ text: `Bullet number ${i}.` }));
+		expect(validateEdits({ edits: many }, allowed)).toHaveLength(MAX_EDITS);
+	});
+
+	it.each([[{}], [{ edits: null }], [{ edits: 'nope' }], [null], ['garbage']])(
+		'returns an empty list for malformed payload %p',
+		(raw) => {
+			expect(validateEdits(raw, allowed)).toEqual([]);
+		},
+	);
+
+	it('keeps good edits alongside bad ones rather than failing the batch', () => {
+		const raw = { edits: [edit({ targetId: 'ghost' }), edit({ text: 'Real bullet.' })] };
+		expect(validateEdits(raw, allowed)).toEqual([{ kind: 'bullet', targetId: 'w1', text: 'Real bullet.' }]);
+	});
+});
+
+describe('buildTailorInput', () => {
+	const occupation = {
+		code: '15-1252.00',
+		title: 'Software Developers',
+		description: 'Design software.',
+		brightOutlook: false,
+		tasks: [{ id: 't1', text: 'Modify existing software.' }],
+		detailedWorkActivities: [],
+		technologySkills: [{ category: 'IDEs', examples: [{ name: 'Git', hot: true }] }],
+		skills: [{ id: 'k1', name: 'Programming', description: 'Writing programs.' }],
+		knowledge: [],
+		abilities: [],
+		unavailable: [],
+	} as OnetOccupation;
+
+	function resume(): ResumeData {
+		return {
+			...structuredClone(defaultResumeData),
+			workExperience: [
+				{
+					id: 'w1',
+					title: 'Software Engineer',
+					company: 'Acme',
+					location: '',
+					startDate: '',
+					endDate: '',
+					isPresent: true,
+					bullets: ['Built an API.'],
+				},
+			],
+			skills: [{ id: 's1', category: 'Languages', skills: 'Python' }],
+		};
+	}
+
+	it('offers every insertable target so the model can only choose a real one', () => {
+		const { allowed: a } = buildTailorInput(resume(), occupation);
+		expect([...a.bullets]).toEqual(['w1']);
+		expect([...a.skills]).toEqual(['s1']);
+	});
+
+	it('includes the resume evidence and the O*NET items in the prompt text', () => {
+		const { prompt } = buildTailorInput(resume(), occupation);
+		expect(prompt).toContain('Built an API.'); // existing bullet, so the model can ground its rewrite
+		expect(prompt).toContain('Modify existing software.'); // O*NET task
+		expect(prompt).toContain('Git'); // technology
+		expect(prompt).toContain('w1'); // target id it must cite back
+	});
+
+	it('does not leak contact details into the prompt', () => {
+		const r = resume();
+		r.personalInfo.email = 'secret@example.com';
+		r.personalInfo.phone = '555-0100';
+		const { prompt } = buildTailorInput(r, occupation);
+		expect(prompt).not.toContain('secret@example.com');
+		expect(prompt).not.toContain('555-0100');
+	});
+});

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -1,0 +1,156 @@
+import type { ResumeData } from '$lib/types';
+import type { OnetOccupation, TailorEdit } from '$lib/onet-types';
+import { bulletTargets, skillTargets } from '$lib/onet-insert';
+
+// A ceiling on how much one click can change, so a runaway response can't
+// rewrite the whole resume in a single pass.
+export const MAX_EDITS = 12;
+
+export interface AllowedTargets {
+	bullets: Set<string>;
+	skills: Set<string>;
+}
+
+export const TAILOR_PROMPT = [
+	'You help tailor a resume toward a specific occupation using O*NET reference data.',
+	'You are given the candidate resume and the O*NET data for the target occupation.',
+	"Choose the items most worth adding, rewrite each one in the resume's existing voice and tense, and assign it to a target.",
+	'',
+	'Grounding rules, in order of importance:',
+	'1. Never claim experience the resume does not already evidence. If the resume shows no management, do not add a bullet about leading a team. If it shows no experience with a technology, do not add that technology.',
+	'2. Rewrite; do not paste. Match the phrasing, tense and level of detail of the bullets already in that entry, and lead with a strong verb.',
+	'3. Prefer a small number of strong, well-grounded additions over filling every slot. Returning few edits, or none, is a correct answer when the resume and the occupation do not overlap.',
+	'4. Do not duplicate something the entry already says in different words.',
+	'',
+	`Return at most ${MAX_EDITS} edits.`,
+	'Every targetId MUST be copied exactly from the target lists below; never invent one.',
+	'Use kind "bullet" with an experience or project id, and kind "skill" with a skill category id.',
+	'A "skill" edit\'s text must be a short skill or technology name, not a sentence.',
+].join('\n');
+
+// Strict json_schema for the OpenAI Responses API.
+export const TAILOR_SCHEMA = {
+	type: 'object',
+	additionalProperties: false,
+	required: ['edits'],
+	properties: {
+		edits: {
+			type: 'array',
+			items: {
+				type: 'object',
+				additionalProperties: false,
+				required: ['kind', 'targetId', 'text'],
+				properties: {
+					kind: { type: 'string', enum: ['bullet', 'skill'] },
+					targetId: { type: 'string' },
+					text: { type: 'string' },
+				},
+			},
+		},
+	},
+} as const;
+
+function scaleLines(label: string, items: { name: string }[]): string[] {
+	return items.length ? [`${label}: ${items.map((i) => i.name).join(', ')}`] : [];
+}
+
+// Build the model input. Only resume content that could justify a bullet is
+// included; contact details are deliberately left out since they can't inform
+// the rewrite and there's no reason to send them.
+export function buildTailorInput(
+	resume: ResumeData,
+	occupation: OnetOccupation,
+): { prompt: string; allowed: AllowedTargets } {
+	const bullets = bulletTargets(resume);
+	const skills = skillTargets(resume);
+
+	const lines: string[] = [TAILOR_PROMPT, '', '=== TARGETS: experience and project entries (kind "bullet") ==='];
+
+	for (const target of bullets) {
+		const entry =
+			resume.workExperience.find((w) => w.id === target.id) ?? resume.projects.find((p) => p.id === target.id);
+		const existing = entry?.bullets.filter(Boolean) ?? [];
+		lines.push(`id=${target.id} | ${target.label}`);
+		lines.push(existing.length ? existing.map((b) => `    - ${b}`).join('\n') : '    (no bullets yet)');
+	}
+
+	lines.push('', '=== TARGETS: skill categories (kind "skill") ===');
+	for (const target of skills) {
+		const category = resume.skills.find((s) => s.id === target.id);
+		lines.push(`id=${target.id} | ${target.label} | currently: ${category?.skills || '(empty)'}`);
+	}
+
+	if (resume.profile.summary.trim()) {
+		lines.push('', '=== Candidate profile summary ===', resume.profile.summary.trim());
+	}
+	if (resume.education.length) {
+		lines.push(
+			'',
+			'=== Education ===',
+			...resume.education.map((e) => `- ${[e.degree, e.major, e.institution].filter(Boolean).join(', ')}`),
+		);
+	}
+
+	lines.push(
+		'',
+		`=== TARGET OCCUPATION: ${occupation.title} (${occupation.code}) ===`,
+		occupation.description,
+		'',
+		'Tasks:',
+		...occupation.tasks.map((t) => `- ${t.text}`),
+	);
+
+	if (occupation.detailedWorkActivities.length) {
+		lines.push('', 'Work activities:', ...occupation.detailedWorkActivities.map((a) => `- ${a.text}`));
+	}
+	if (occupation.technologySkills.length) {
+		lines.push(
+			'',
+			'Technology:',
+			...occupation.technologySkills.map((c) => `- ${c.category}: ${c.examples.map((e) => e.name).join(', ')}`),
+		);
+	}
+	lines.push(
+		...scaleLines('Skills', occupation.skills),
+		...scaleLines('Knowledge', occupation.knowledge),
+		...scaleLines('Abilities', occupation.abilities),
+	);
+
+	return {
+		prompt: lines.join('\n'),
+		allowed: { bullets: new Set(bullets.map((b) => b.id)), skills: new Set(skills.map((s) => s.id)) },
+	};
+}
+
+// The model can return ids it was never offered, duplicate suggestions, or more
+// edits than asked for. Everything that isn't provably addressable is dropped
+// rather than failing the batch, so one bad entry can't lose the good ones.
+export function validateEdits(raw: unknown, allowed: AllowedTargets): TailorEdit[] {
+	const list = (raw as { edits?: unknown })?.edits;
+	if (!Array.isArray(list)) return [];
+
+	const out: TailorEdit[] = [];
+	const seen = new Set<string>();
+
+	for (const item of list) {
+		if (out.length >= MAX_EDITS) break;
+
+		const { kind, targetId, text } = (item ?? {}) as Record<string, unknown>;
+		if (kind !== 'bullet' && kind !== 'skill') continue;
+		if (typeof targetId !== 'string' || typeof text !== 'string') continue;
+
+		const trimmed = text.trim();
+		if (!trimmed) continue;
+
+		const pool = kind === 'bullet' ? allowed.bullets : allowed.skills;
+		if (!pool.has(targetId)) continue;
+
+		const key = `${kind}:${targetId}:${trimmed.toLowerCase()}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+
+		out.push({ kind, targetId, text: trimmed });
+	}
+
+	return out;
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { resumeStore } from '$lib/store';
+	import { onetStore } from '$lib/onet-store';
 	import { generateTypstCode } from '$lib/typst-generator';
 	import { initCompiler, compileToPdf, compileToSvg, downloadPdf } from '$lib/pdf-compiler';
 	import type { ResumeData } from '$lib/types';
@@ -9,6 +10,7 @@
 
 	import AppHeader from '$lib/components/AppHeader.svelte';
 	import UploadModal from '$lib/components/UploadModal.svelte';
+	import OnetDrawer from '$lib/components/OnetDrawer.svelte';
 	import AppFooter from '$lib/components/AppFooter.svelte';
 	import TabBar from '$lib/components/TabBar.svelte';
 	import PreviewPanel from '$lib/components/PreviewPanel.svelte';
@@ -34,6 +36,7 @@
 	let svgPreview = $state<string>('');
 	let isPreviewLoading = $state(false);
 	let uploadOpen = $state(false);
+	let tailorOpen = $state(false);
 	let showReviewBanner = $state(false);
 	let previewDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 	let isOverOnePage = $derived(estimateOverOnePage(data));
@@ -58,6 +61,7 @@
 
 	onMount(() => {
 		resumeStore.loadFromStorage();
+		onetStore.loadFromStorage();
 		const unsub = resumeStore.subscribe((val) => {
 			data = val;
 		});
@@ -110,7 +114,10 @@
 		{isOverOnePage}
 		onDownload={downloadPdfFile}
 		onUpload={() => (uploadOpen = true)}
+		onTailor={() => (tailorOpen = true)}
 	/>
+
+	<OnetDrawer bind:open={tailorOpen} bind:data onInserted={() => (showReviewBanner = true)} />
 
 	<main class="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8">
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -120,7 +127,10 @@
 					<div
 						class="mb-4 flex items-start justify-between gap-2 rounded border border-purple-300 bg-purple-50 px-3 py-2 text-sm text-purple-800"
 					>
-						<span>AI filled the highlighted (purple) fields — please review them for accuracy.</span>
+						<span
+							>The highlighted (purple) fields were filled in for you, by AI extraction or from O*NET — please review
+							them for accuracy.</span
+						>
 						<button
 							class="secondary text-xs px-2 py-0.5"
 							onclick={() => (showReviewBanner = false)}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -106,7 +106,13 @@
 	];
 </script>
 
-<div class="min-h-screen bg-gray-100 flex flex-col">
+<!--
+	Locked to the viewport from lg up so the page itself never scrolls: main takes
+	the leftover space and the two panels scroll inside it, which means header and
+	footer heights no longer have to be guessed at. Below lg the panels stack, so
+	the page scrolls normally there.
+-->
+<div class="min-h-screen lg:h-screen lg:overflow-hidden bg-gray-100 flex flex-col">
 	<AppHeader
 		bind:showCode
 		{isCompiling}
@@ -119,10 +125,10 @@
 
 	<OnetDrawer bind:open={tailorOpen} bind:data onInserted={() => (showReviewBanner = true)} />
 
-	<main class="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8">
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+	<main class="w-full max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8 lg:flex-1 lg:min-h-0">
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:h-full lg:min-h-0">
 			<!-- Form Panel -->
-			<div class="bg-white rounded-lg shadow p-6 overflow-auto max-h-[calc(100vh-10rem)]">
+			<div class="bg-white rounded-lg shadow p-6 overflow-auto max-h-[calc(100vh-10rem)] lg:max-h-none lg:h-full">
 				{#if showReviewBanner}
 					<div
 						class="mb-4 flex items-start justify-between gap-2 rounded border border-purple-300 bg-purple-50 px-3 py-2 text-sm text-purple-800"

--- a/web/src/routes/api/onet/occupation/[code]/+server.ts
+++ b/web/src/routes/api/onet/occupation/[code]/+server.ts
@@ -1,0 +1,20 @@
+import type { RequestHandler } from './$types';
+import { fetchOccupation, isValidOnetCode, onetError } from '$lib/server/onet';
+import { onetFail, onetOk, onetKey } from '$lib/server/onet-route';
+
+export const prerender = false;
+
+export const GET: RequestHandler = async ({ params }) => {
+	const code = params.code ?? '';
+	if (!isValidOnetCode(code)) return onetFail(onetError('invalid_code'));
+
+	const key = onetKey();
+	if (!key) return onetFail(onetError('auth'));
+
+	try {
+		// One request from the browser; the seven-way O*NET fan-out happens here.
+		return onetOk({ occupation: await fetchOccupation(code, key) });
+	} catch (err) {
+		return onetFail(err);
+	}
+};

--- a/web/src/routes/api/onet/search/+server.ts
+++ b/web/src/routes/api/onet/search/+server.ts
@@ -1,0 +1,23 @@
+import type { RequestHandler } from './$types';
+import { searchOccupations, onetError } from '$lib/server/onet';
+import { onetFail, onetOk, onetKey } from '$lib/server/onet-route';
+
+// The root layout prerenders pages; this endpoint is dynamic.
+export const prerender = false;
+
+const MAX_KEYWORD = 100;
+
+export const GET: RequestHandler = async ({ url }) => {
+	const keyword = (url.searchParams.get('keyword') ?? '').trim();
+	if (!keyword) return onetOk({ occupations: [] });
+	if (keyword.length > MAX_KEYWORD) return onetFail(onetError('invalid_code'));
+
+	const key = onetKey();
+	if (!key) return onetFail(onetError('auth'));
+
+	try {
+		return onetOk({ occupations: await searchOccupations(keyword, key) });
+	} catch (err) {
+		return onetFail(err);
+	}
+};

--- a/web/src/routes/api/onet/tailor/+server.ts
+++ b/web/src/routes/api/onet/tailor/+server.ts
@@ -1,0 +1,75 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
+import OpenAI from 'openai';
+import { MODEL, mapOpenAIError, extractError } from '$lib/server/extraction';
+import { fetchOccupation, isValidOnetCode, onetError } from '$lib/server/onet';
+import { onetFail, onetKey } from '$lib/server/onet-route';
+import { buildTailorInput, validateEdits, TAILOR_SCHEMA } from '$lib/server/tailor';
+import type { ResumeData } from '$lib/types';
+import type { ExtractError } from '$lib/server/extraction';
+
+export const prerender = false;
+
+// Same { error: { code, message } } envelope the other endpoints use.
+function fail(e: ExtractError): Response {
+	return json({ error: { code: e.code, message: e.message } }, { status: e.status });
+}
+
+// Personalised to the caller's resume, so unlike the other O*NET routes this
+// one must not be cached at the edge.
+export const POST: RequestHandler = async ({ request }) => {
+	let body: { resume?: ResumeData; code?: string };
+	try {
+		body = await request.json();
+	} catch {
+		return onetFail(onetError('invalid_code'));
+	}
+
+	const code = body.code ?? '';
+	if (!isValidOnetCode(code)) return onetFail(onetError('invalid_code'));
+	if (!body.resume || typeof body.resume !== 'object') return onetFail(onetError('invalid_code'));
+
+	const key = onetKey();
+	if (!key) return onetFail(onetError('auth'));
+	if (!env.OPENAI_API_KEY) return fail(extractError('auth'));
+
+	// Fetch the occupation server-side rather than trusting a client-supplied
+	// copy; the edge cache means this is usually already warm.
+	let occupation;
+	try {
+		occupation = await fetchOccupation(code, key);
+	} catch (err) {
+		return onetFail(err);
+	}
+
+	const { prompt, allowed } = buildTailorInput(body.resume, occupation);
+	if (allowed.bullets.size === 0 && allowed.skills.size === 0) {
+		return json({ edits: [], reason: 'no_targets' });
+	}
+
+	try {
+		const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+		const response = await client.responses.create({
+			model: MODEL,
+			input: [{ role: 'user', content: [{ type: 'input_text', text: prompt }] }],
+			reasoning: { effort: 'medium' },
+			text: {
+				format: {
+					type: 'json_schema',
+					name: 'tailor_edits',
+					strict: true,
+					schema: TAILOR_SCHEMA as unknown as Record<string, unknown>,
+				},
+			},
+		});
+
+		const raw = response.output_text;
+		if (!raw) return fail(extractError('parse_failed'));
+
+		return json({ edits: validateEdits(JSON.parse(raw), allowed) });
+	} catch (err) {
+		if (err instanceof SyntaxError) return fail(extractError('parse_failed'));
+		return fail(mapOpenAIError(err));
+	}
+};


### PR DESCRIPTION
This pull request introduces the O*NET Job Tailoring feature, which integrates official O*NET occupational data directly into the resume builder. Users can now reference, search, and insert occupation-specific tasks, skills, and technologies into their resumes, with options for both manual and AI-assisted tailoring. The implementation covers backend integration with O*NET Web Services, robust error handling, client-side state management, and full attribution in the UI. Comprehensive tests ensure reliability and correctness.

The most important changes are:

**Feature: O*NET Job Tailoring Integration**
- Added a complete design specification for O*NET Job Tailoring, detailing the user experience, API usage, architecture, error handling, and testing strategy. This includes both manual insertion and an optional AI-powered auto-tailor feature.
- Introduced a new environment variable `ONET_API_KEY` for authenticating requests to the O*NET Web Services API, with documentation in `.env.example`.

**UI Enhancements and Attribution**
- Updated the application footer in `AppFooter.svelte` to include the required O*NET attribution badge and license text, complying with CC BY 4.0 requirements.
- Added a "Tailor to a Job" button in `AppHeader.svelte` to open the O*NET drawer, making the feature easily accessible. [[1]](diffhunk://#diff-c4b2a5497cd5e10cb5106b7618b10b8a2308a42d90e0ae1ecc90b32f8455f7c3R9-R17) [[2]](diffhunk://#diff-c4b2a5497cd5e10cb5106b7618b10b8a2308a42d90e0ae1ecc90b32f8455f7c3R27)
- Implemented the `OnetInsertMenu.svelte` component for selecting where to insert O*NET items into the resume, supporting both existing and new categories.

**Backend and Client Logic**
- Implemented the `applyTailorEdits` function and its test suite to apply AI-suggested resume edits safely and consistently, ensuring edits are only made to valid targets and duplicates are avoided. [[1]](diffhunk://#diff-d458bcb37e874de9b00c49a978a617414ca3eb28317013873b189561abbf13e1R1-R32) [[2]](diffhunk://#diff-6e422dae6aba631749d01e052f73b12307239baf9065df75130718a7553685c1R1-R93)

**Other UI Improvements**
- Improved the `PreviewPanel.svelte` to better handle viewport height on large screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Tailor to a Job” functionality using O*NET occupation data.
  - Search for occupations and review relevant tasks, activities, skills, and competencies.
  - Insert selected recommendations into resume sections or create new skill categories.
  - Optionally generate AI-assisted tailoring suggestions with edits highlighted for review.
  - Selected occupations persist between sessions.

- **Improvements**
  - Expanded large-screen preview panels to use available height.
  - Added required O*NET attribution and licensing information to the footer.

- **Configuration**
  - Added setup guidance for the O*NET API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->