### PR TITLE
Fix AI tailoring edits and long-resume compression

### DIFF
--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -159,15 +159,21 @@
 			const result = applyTailorEdits(data, edits);
 			data = result.data;
 			applyPaths(result.paths);
+			if (result.removed > 0 && result.paths.length === 0) onInserted();
 
-			if (result.paths.length === 0) {
+			const changes = result.paths.length + result.removed;
+			if (changes === 0) {
 				tailorNote =
 					edits.length === 0
 						? "The AI didn't find anything in this occupation your resume can already back up."
 						: 'Everything the AI suggested is already on your resume.';
 			} else {
-				const n = result.paths.length;
-				tailorNote = `Added ${n} ${n === 1 ? 'item' : 'items'}, highlighted in purple. Check the wording before exporting.`;
+				const revised = result.paths.length;
+				const parts = [
+					revised ? `${revised} ${revised === 1 ? 'item added or rewritten' : 'items added or rewritten'}` : '',
+					result.removed ? `${result.removed} ${result.removed === 1 ? 'bullet removed' : 'bullets removed'}` : '',
+				].filter(Boolean);
+				tailorNote = `${parts.join(', ')}. Rewritten and added text is highlighted in purple; review every change before exporting.`;
 			}
 		} catch {
 			tailorError = GENERIC_ERROR;
@@ -295,8 +301,9 @@
 						{tailoring ? 'Tailoring...' : 'Auto-tailor with AI'}
 					</button>
 					<p class="mt-1 text-xs text-gray-500">
-						Picks the items that fit your background, rewrites them in your voice, and adds them straight in. Review the
-						purple text before you export &mdash; AI can overstate what you have actually done.
+						Picks grounded improvements and applies them straight in. If your resume is over one page, it tightens
+						existing bullets instead of adding more. Review every change before you export &mdash; AI can overstate what
+						you have done.
 					</p>
 					{#if tailorNote}
 						<p class="mt-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-700">{tailorNote}</p>

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -24,8 +24,13 @@ function seed(): ResumeData {
 	};
 }
 
-const bullet = (targetId: string, text: string): TailorEdit => ({ kind: 'bullet', targetId, text });
-const skill = (targetId: string, text: string): TailorEdit => ({ kind: 'skill', targetId, text });
+const bullet = (targetId: string, text: string): TailorEdit => ({
+	kind: 'add_bullet',
+	targetId,
+	text,
+	bulletIndex: -1,
+});
+const skill = (targetId: string, text: string): TailorEdit => ({ kind: 'skill', targetId, text, bulletIndex: -1 });
 
 describe('applyTailorEdits', () => {
 	it('appends a bullet to the named experience entry', () => {
@@ -81,6 +86,24 @@ describe('applyTailorEdits', () => {
 
 		expect(data.workExperience[0].bullets).toEqual(['Built an API.']);
 		expect(paths).toEqual([]);
+	});
+
+	it('rewrites an existing bullet in place', () => {
+		const { data, paths } = applyTailorEdits(seed(), [
+			{ kind: 'rewrite_bullet', targetId: 'w1', bulletIndex: 0, text: 'Built and shipped a production API.' },
+		]);
+
+		expect(data.workExperience[0].bullets).toEqual(['Built and shipped a production API.']);
+		expect(paths).toEqual(['workExperience.0.bullets.0']);
+	});
+
+	it('removes a least-relevant bullet when shortening a resume', () => {
+		const { data, removed } = applyTailorEdits(seed(), [
+			{ kind: 'remove_bullet', targetId: 'w1', bulletIndex: 0, text: '' },
+		]);
+
+		expect(data.workExperience[0].bullets).toEqual([]);
+		expect(removed).toBe(1);
 	});
 
 	it('leaves the resume untouched when there is nothing to apply', () => {

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -7,9 +7,13 @@ import { appendBullet, appendSkill, bulletTargets } from './onet-insert';
 // duplicate suppression). Returns the new resume and the dotted paths to
 // highlight. An edit whose target has since disappeared is skipped rather than
 // aborting the batch.
-export function applyTailorEdits(data: ResumeData, edits: TailorEdit[]): { data: ResumeData; paths: string[] } {
+export function applyTailorEdits(
+	data: ResumeData,
+	edits: TailorEdit[],
+): { data: ResumeData; paths: string[]; removed: number } {
 	let next = data;
 	const paths: string[] = [];
+	let removed = 0;
 
 	for (const edit of edits) {
 		if (edit.kind === 'skill') {
@@ -22,11 +26,36 @@ export function applyTailorEdits(data: ResumeData, edits: TailorEdit[]): { data:
 		// Look the kind up fresh each time: earlier edits can change the arrays.
 		const target = bulletTargets(next).find((t) => t.id === edit.targetId);
 		if (!target) continue;
+		if (edit.kind === 'add_bullet') {
+			const result = appendBullet(next, target.kind, edit.targetId, edit.text);
+			next = result.data;
+			if (result.path) paths.push(result.path);
+			continue;
+		}
 
-		const result = appendBullet(next, target.kind, edit.targetId, edit.text);
-		next = result.data;
-		if (result.path) paths.push(result.path);
+		const key = target.kind === 'experience' ? 'workExperience' : 'projects';
+		const entries = next[key];
+		const entryIndex = entries.findIndex((entry) => entry.id === edit.targetId);
+		const entry = entries[entryIndex];
+		if (!entry || edit.bulletIndex < 0 || edit.bulletIndex >= entry.bullets.length) continue;
+
+		if (edit.kind === 'remove_bullet') {
+			const updated = [...entries];
+			updated[entryIndex] = { ...entry, bullets: entry.bullets.filter((_, index) => index !== edit.bulletIndex) };
+			next = { ...next, [key]: updated };
+			removed++;
+			continue;
+		}
+
+		if (edit.kind !== 'rewrite_bullet' || entry.bullets[edit.bulletIndex] === edit.text) continue;
+		const updated = [...entries];
+		updated[entryIndex] = {
+			...entry,
+			bullets: entry.bullets.map((bullet, index) => (index === edit.bulletIndex ? edit.text : bullet)),
+		};
+		next = { ...next, [key]: updated };
+		paths.push(`${key}.${entryIndex}.bullets.${edit.bulletIndex}`);
 	}
 
-	return { data: next, paths };
+	return { data: next, paths, removed };
 }

--- a/web/src/lib/onet-types.ts
+++ b/web/src/lib/onet-types.ts
@@ -59,9 +59,12 @@ export const onetSectionLabels: Record<OnetSectionName, string> = {
 };
 
 // One change proposed by the AI tailor pass. `targetId` is the id of a work
-// experience / project entry (kind 'bullet') or a skill category (kind 'skill').
+// experience / project entry (the bullet kinds) or a skill category (skill).
+// bulletIndex identifies an existing bullet for rewrite/remove; it is -1 for
+// additions and skills.
 export interface TailorEdit {
-	kind: 'bullet' | 'skill';
+	kind: 'add_bullet' | 'rewrite_bullet' | 'remove_bullet' | 'skill';
 	targetId: string;
 	text: string;
+	bulletIndex: number;
 }

--- a/web/src/lib/server/tailor.test.ts
+++ b/web/src/lib/server/tailor.test.ts
@@ -7,13 +7,13 @@ import type { OnetOccupation } from '$lib/onet-types';
 const allowed = { bullets: new Set(['w1', 'p1']), skills: new Set(['s1']) };
 
 function edit(over: Record<string, unknown> = {}) {
-	return { kind: 'bullet', targetId: 'w1', text: 'Shipped a thing.', ...over };
+	return { kind: 'add_bullet', targetId: 'w1', text: 'Shipped a thing.', bulletIndex: -1, ...over };
 }
 
 describe('validateEdits', () => {
 	it('keeps a well-formed edit', () => {
 		expect(validateEdits({ edits: [edit()] }, allowed)).toEqual([
-			{ kind: 'bullet', targetId: 'w1', text: 'Shipped a thing.' },
+			{ kind: 'add_bullet', targetId: 'w1', text: 'Shipped a thing.', bulletIndex: -1 },
 		]);
 	});
 
@@ -24,7 +24,7 @@ describe('validateEdits', () => {
 	});
 
 	it('drops a bullet edit aimed at a skill category id', () => {
-		expect(validateEdits({ edits: [edit({ kind: 'bullet', targetId: 's1' })] }, allowed)).toEqual([]);
+		expect(validateEdits({ edits: [edit({ kind: 'add_bullet', targetId: 's1' })] }, allowed)).toEqual([]);
 	});
 
 	it('drops a skill edit aimed at an experience id', () => {
@@ -67,7 +67,9 @@ describe('validateEdits', () => {
 
 	it('keeps good edits alongside bad ones rather than failing the batch', () => {
 		const raw = { edits: [edit({ targetId: 'ghost' }), edit({ text: 'Real bullet.' })] };
-		expect(validateEdits(raw, allowed)).toEqual([{ kind: 'bullet', targetId: 'w1', text: 'Real bullet.' }]);
+		expect(validateEdits(raw, allowed)).toEqual([
+			{ kind: 'add_bullet', targetId: 'w1', text: 'Real bullet.', bulletIndex: -1 },
+		]);
 	});
 });
 

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -1,6 +1,7 @@
 import type { ResumeData } from '$lib/types';
 import type { OnetOccupation, TailorEdit } from '$lib/onet-types';
 import { bulletTargets, skillTargets } from '$lib/onet-insert';
+import { estimateOverOnePage } from '$lib/resume-utils';
 
 // A ceiling on how much one click can change, so a runaway response can't
 // rewrite the whole resume in a single pass.
@@ -9,22 +10,24 @@ export const MAX_EDITS = 12;
 export interface AllowedTargets {
 	bullets: Set<string>;
 	skills: Set<string>;
+	bulletCounts?: Map<string, number>;
 }
 
 export const TAILOR_PROMPT = [
-	'You help tailor a resume toward a specific occupation using O*NET reference data.',
+	'You actively tailor a resume toward a specific occupation using O*NET reference data.',
 	'You are given the candidate resume and the O*NET data for the target occupation.',
-	"Choose the items most worth adding, rewrite each one in the resume's existing voice and tense, and assign it to a target.",
+	"Choose the strongest relevant changes, rewrite in the resume's existing voice and tense, and assign each to an exact target.",
 	'',
 	'Grounding rules, in order of importance:',
 	'1. Never claim experience the resume does not already evidence. If the resume shows no management, do not add a bullet about leading a team. If it shows no experience with a technology, do not add that technology.',
 	'2. Rewrite; do not paste. Match the phrasing, tense and level of detail of the bullets already in that entry, and lead with a strong verb.',
-	'3. Prefer a small number of strong, well-grounded additions over filling every slot. Returning few edits, or none, is a correct answer when the resume and the occupation do not overlap.',
+	'3. Prefer a small number of strong, well-grounded changes over filling every slot. Returning few edits, or none, is correct only when the resume and the occupation do not overlap.',
 	'4. Do not duplicate something the entry already says in different words.',
 	'',
 	`Return at most ${MAX_EDITS} edits.`,
 	'Every targetId MUST be copied exactly from the target lists below; never invent one.',
-	'Use kind "bullet" with an experience or project id, and kind "skill" with a skill category id.',
+	'Use kind "add_bullet" to add a grounded bullet, "rewrite_bullet" to improve an existing bullet, or "remove_bullet" to remove an existing bullet. Use kind "skill" with a skill category id.',
+	'For rewrite_bullet and remove_bullet, bulletIndex MUST be the zero-based index shown beside that bullet. For add_bullet and skill, bulletIndex MUST be -1.',
 	'A "skill" edit\'s text must be a short skill or technology name, not a sentence.',
 ].join('\n');
 
@@ -41,9 +44,10 @@ export const TAILOR_SCHEMA = {
 				additionalProperties: false,
 				required: ['kind', 'targetId', 'text'],
 				properties: {
-					kind: { type: 'string', enum: ['bullet', 'skill'] },
+					kind: { type: 'string', enum: ['add_bullet', 'rewrite_bullet', 'remove_bullet', 'skill'] },
 					targetId: { type: 'string' },
 					text: { type: 'string' },
+					bulletIndex: { type: 'integer', minimum: -1 },
 				},
 			},
 		},
@@ -64,14 +68,23 @@ export function buildTailorInput(
 	const bullets = bulletTargets(resume);
 	const skills = skillTargets(resume);
 
-	const lines: string[] = [TAILOR_PROMPT, '', '=== TARGETS: experience and project entries (kind "bullet") ==='];
+	const isOverOnePage = estimateOverOnePage(resume);
+	const lines: string[] = [
+		TAILOR_PROMPT,
+		'',
+		isOverOnePage
+			? '=== LENGTH MODE ===\nThis resume is estimated to exceed one page. Do not add content unless it replaces more text. Prioritize concise rewrite_bullet edits and remove_bullet edits for generic, repetitive, or least relevant bullets until the resume is tighter.'
+			: '=== LENGTH MODE ===\nThis resume is within the one-page target. Make concrete, grounded improvements; use add_bullet only when it adds job-relevant evidence not already stated.',
+		'',
+		'=== TARGETS: experience and project entries (bullet kinds) ===',
+	];
 
 	for (const target of bullets) {
 		const entry =
 			resume.workExperience.find((w) => w.id === target.id) ?? resume.projects.find((p) => p.id === target.id);
 		const existing = entry?.bullets.filter(Boolean) ?? [];
 		lines.push(`id=${target.id} | ${target.label}`);
-		lines.push(existing.length ? existing.map((b) => `    - ${b}`).join('\n') : '    (no bullets yet)');
+		lines.push(existing.length ? existing.map((b, index) => `    [${index}] ${b}`).join('\n') : '    (no bullets yet)');
 	}
 
 	lines.push('', '=== TARGETS: skill categories (kind "skill") ===');
@@ -118,7 +131,18 @@ export function buildTailorInput(
 
 	return {
 		prompt: lines.join('\n'),
-		allowed: { bullets: new Set(bullets.map((b) => b.id)), skills: new Set(skills.map((s) => s.id)) },
+		allowed: {
+			bullets: new Set(bullets.map((b) => b.id)),
+			skills: new Set(skills.map((s) => s.id)),
+			bulletCounts: new Map(
+				bullets.map((target) => {
+					const entry =
+						resume.workExperience.find((work) => work.id === target.id) ??
+						resume.projects.find((project) => project.id === target.id);
+					return [target.id, entry?.bullets.length ?? 0];
+				}),
+			),
+		},
 	};
 }
 
@@ -135,21 +159,35 @@ export function validateEdits(raw: unknown, allowed: AllowedTargets): TailorEdit
 	for (const item of list) {
 		if (out.length >= MAX_EDITS) break;
 
-		const { kind, targetId, text } = (item ?? {}) as Record<string, unknown>;
-		if (kind !== 'bullet' && kind !== 'skill') continue;
-		if (typeof targetId !== 'string' || typeof text !== 'string') continue;
+		const { kind, targetId, text, bulletIndex } = (item ?? {}) as Record<string, unknown>;
+		if (kind !== 'add_bullet' && kind !== 'rewrite_bullet' && kind !== 'remove_bullet' && kind !== 'skill') continue;
+		if (
+			typeof targetId !== 'string' ||
+			typeof text !== 'string' ||
+			typeof bulletIndex !== 'number' ||
+			!Number.isInteger(bulletIndex)
+		)
+			continue;
 
 		const trimmed = text.trim();
-		if (!trimmed) continue;
+		if (kind !== 'remove_bullet' && !trimmed) continue;
+		if ((kind === 'add_bullet' || kind === 'skill') && bulletIndex !== -1) continue;
+		if ((kind === 'rewrite_bullet' || kind === 'remove_bullet') && bulletIndex < 0) continue;
 
-		const pool = kind === 'bullet' ? allowed.bullets : allowed.skills;
+		const pool = kind === 'skill' ? allowed.skills : allowed.bullets;
 		if (!pool.has(targetId)) continue;
+		if (
+			(kind === 'rewrite_bullet' || kind === 'remove_bullet') &&
+			allowed.bulletCounts !== undefined &&
+			bulletIndex >= (allowed.bulletCounts.get(targetId) ?? 0)
+		)
+			continue;
 
-		const key = `${kind}:${targetId}:${trimmed.toLowerCase()}`;
+		const key = `${kind}:${targetId}:${bulletIndex}:${trimmed.toLowerCase()}`;
 		if (seen.has(key)) continue;
 		seen.add(key);
 
-		out.push({ kind, targetId, text: trimmed });
+		out.push({ kind, targetId, text: trimmed, bulletIndex });
 	}
 
 	return out;


### PR DESCRIPTION
## Summary\n- apply AI-proposed bullet additions, rewrites, and removals to the resume\n- switch tailoring into compression mode when the resume is estimated to exceed one page\n- validate edit targets and bullet indexes before applying them\n\n## Validation\n- bun run test\n- bun run check\n- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume tailoring can now rewrite existing bullets, add new bullets, or remove bullets for more precise edits.
  * Tailoring better accounts for resume length and can help tighten over-long resumes.

* **Improvements**
  * Post-tailoring messages now report the number of added, rewritten, and removed items with clearer wording.
  * Removed-only tailoring changes are now applied and highlighted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->