### PR TITLE
Fix tailor AI schema 500

### DIFF
--- a/web/src/lib/server/tailor.test.ts
+++ b/web/src/lib/server/tailor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateEdits, MAX_EDITS, buildTailorInput } from './tailor';
+import { validateEdits, MAX_EDITS, buildTailorInput, TAILOR_SCHEMA } from './tailor';
 import { defaultResumeData } from '$lib/types';
 import type { ResumeData } from '$lib/types';
 import type { OnetOccupation } from '$lib/onet-types';
@@ -11,6 +11,10 @@ function edit(over: Record<string, unknown> = {}) {
 }
 
 describe('validateEdits', () => {
+	it('requires every declared edit property for strict OpenAI JSON schema compatibility', () => {
+		expect(TAILOR_SCHEMA.properties.edits.items.required).toEqual(['kind', 'targetId', 'text', 'bulletIndex']);
+	});
+
 	it('keeps a well-formed edit', () => {
 		expect(validateEdits({ edits: [edit()] }, allowed)).toEqual([
 			{ kind: 'add_bullet', targetId: 'w1', text: 'Shipped a thing.', bulletIndex: -1 },

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -42,7 +42,7 @@ export const TAILOR_SCHEMA = {
 			items: {
 				type: 'object',
 				additionalProperties: false,
-				required: ['kind', 'targetId', 'text'],
+				required: ['kind', 'targetId', 'text', 'bulletIndex'],
 				properties: {
 					kind: { type: 'string', enum: ['add_bullet', 'rewrite_bullet', 'remove_bullet', 'skill'] },
 					targetId: { type: 'string' },


### PR DESCRIPTION
## Summary\n- require ulletIndex in every strict JSON-schema edit object\n- add a regression test for strict-schema compatibility\n\nThis prevents OpenAI from rejecting the tailor response schema and returning a 500.\n\n## Validation\n- bun run test\n- bun run check\n- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved structured response validation to require an edit position for each generated edit.
  - Ensured edit data includes all required fields for compatibility with strict response validation.

- **Tests**
  - Added coverage confirming that edit entries must include the required properties and reject incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->