### PR TITLE
feat: tailor entire resumes with font controls

### DIFF
--- a/web/src/lib/components/UploadModal.svelte
+++ b/web/src/lib/components/UploadModal.svelte
@@ -106,7 +106,7 @@
 					onclick={() => fileInput?.click()}
 				>
 					<span class="text-gray-600">Drag a file here, or click to browse</span>
-					<span class="block text-xs text-gray-400 mt-1">PDF, DOCX, or TXT — max 5 MB</span>
+					<span class="block text-xs text-gray-400 mt-1">PDF, DOCX, or TXT - max 5 MB</span>
 				</button>
 				<input bind:this={fileInput} type="file" accept={ACCEPT} class="hidden" onchange={onPick} />
 			{:else if status === 'processing'}

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -106,6 +106,15 @@ describe('applyTailorEdits', () => {
 		expect(removed).toBe(1);
 	});
 
+	it('applies a validated font size adjustment', () => {
+		const { data, paths } = applyTailorEdits(seed(), [
+			{ kind: 'set_font', targetId: 'baseSize', bulletIndex: -1, text: '8.1' },
+		]);
+
+		expect(data.fonts.baseSize).toBe(8.1);
+		expect(paths).toContain('fonts.baseSize');
+	});
+
 	it('leaves the resume untouched when there is nothing to apply', () => {
 		const before = seed();
 		const { data, paths } = applyTailorEdits(before, []);

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -16,6 +16,15 @@ export function applyTailorEdits(
 	let removed = 0;
 
 	for (const edit of edits) {
+		if (edit.kind === 'set_font') {
+			const key = edit.targetId as keyof ResumeData['fonts'];
+			if (!(key in next.fonts)) continue;
+			const value = Number(edit.text);
+			if (!Number.isFinite(value) || value === next.fonts[key]) continue;
+			next = { ...next, fonts: { ...next.fonts, [key]: value } };
+			paths.push(`fonts.${key}`);
+			continue;
+		}
 		if (edit.kind === 'rewrite_field') {
 			if (edit.targetId === 'profile') {
 				if (edit.text === next.profile.summary) continue;

--- a/web/src/lib/onet-types.ts
+++ b/web/src/lib/onet-types.ts
@@ -1,5 +1,5 @@
 // Types for O*NET Web Services data. Kept separate from types.ts, which models
-// the resume itself — a target occupation is reference data and never renders.
+// the resume itself - a target occupation is reference data and never renders.
 
 export interface OnetOccupationRef {
 	code: string;

--- a/web/src/lib/onet-types.ts
+++ b/web/src/lib/onet-types.ts
@@ -63,7 +63,7 @@ export const onetSectionLabels: Record<OnetSectionName, string> = {
 // bulletIndex identifies an existing bullet for rewrite/remove; it is -1 for
 // additions and skills.
 export interface TailorEdit {
-	kind: 'add_bullet' | 'rewrite_bullet' | 'remove_bullet' | 'rewrite_field' | 'skill';
+	kind: 'add_bullet' | 'rewrite_bullet' | 'remove_bullet' | 'rewrite_field' | 'set_font' | 'skill';
 	targetId: string;
 	text: string;
 	bulletIndex: number;

--- a/web/src/lib/server/extraction.ts
+++ b/web/src/lib/server/extraction.ts
@@ -20,7 +20,7 @@ const MESSAGES: Record<ExtractErrorCode, string> = {
 	invalid_file: 'Unsupported file. Upload a PDF, DOCX, or TXT.',
 	file_too_large: 'File is too large (max 5 MB).',
 	quota_exceeded: 'AI credit limit reached. Please try again later.',
-	rate_limited: 'Too many requests — wait a moment and retry.',
+	rate_limited: 'Too many requests - wait a moment and retry.',
 	auth: 'AI service is misconfigured (API key).',
 	upstream_unavailable: "Can't reach the AI service. Check your connection and retry.",
 	parse_failed: "Couldn't read that file. Try another format.",

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -27,8 +27,9 @@ export const TAILOR_PROMPT = [
 	'',
 	`Return at most ${MAX_EDITS} edits.`,
 	'Every targetId MUST be copied exactly from the target lists below; never invent one.',
-	'Use kind "add_bullet" to add a grounded bullet, "rewrite_bullet" to improve an existing bullet, "remove_bullet" to remove an existing bullet, "rewrite_field" to tailor an explicitly listed profile, project, education, leadership, or achievement field, or "skill" with a skill category id.',
+	'Use kind "add_bullet" to add a grounded bullet, "rewrite_bullet" to improve an existing bullet, "remove_bullet" to remove an existing bullet, "rewrite_field" to tailor an explicitly listed profile, project, education, leadership, or achievement field, "set_font" to adjust one listed font size, or "skill" with a skill category id.',
 	'For rewrite_bullet and remove_bullet, bulletIndex MUST be the zero-based index shown beside that bullet. For add_bullet and skill, bulletIndex MUST be -1.',
+	'For rewrite_field and set_font, bulletIndex MUST be -1. set_font text MUST be a numeric point size within the listed bounds, and should be used to help an overlong resume fit one page.',
 	'A "skill" edit\'s text must be a short skill or technology name, not a sentence.',
 ].join('\n');
 
@@ -45,7 +46,10 @@ export const TAILOR_SCHEMA = {
 				additionalProperties: false,
 				required: ['kind', 'targetId', 'text', 'bulletIndex'],
 				properties: {
-					kind: { type: 'string', enum: ['add_bullet', 'rewrite_bullet', 'remove_bullet', 'rewrite_field', 'skill'] },
+					kind: {
+						type: 'string',
+						enum: ['add_bullet', 'rewrite_bullet', 'remove_bullet', 'rewrite_field', 'set_font', 'skill'],
+					},
 					targetId: { type: 'string' },
 					text: { type: 'string' },
 					bulletIndex: { type: 'integer', minimum: -1 },
@@ -81,10 +85,15 @@ export function buildTailorInput(
 	];
 	const skills = skillTargets(resume);
 	const fields = resume.profile.summary.trim() ? ['profile'] : [];
+	const fontBounds = 'baseSize=6-14, nameSize=14-32, headingSize=10-24, contactSize=7-16';
 
 	const isOverOnePage = estimateOverOnePage(resume);
 	const lines: string[] = [
 		TAILOR_PROMPT,
+		'',
+		`=== CURRENT FONT CONTROLS ===\n${fontBounds}\n${Object.entries(resume.fonts)
+			.map(([key, value]) => `${key}=${value}pt`)
+			.join(', ')}`,
 		'',
 		isOverOnePage
 			? '=== LENGTH MODE ===\nThis resume is estimated to exceed one page. Do not add content unless it replaces more text. Prioritize concise rewrite_bullet edits and remove_bullet edits for generic, repetitive, or least relevant bullets until the resume is tighter.'
@@ -175,7 +184,7 @@ export function buildTailorInput(
 		allowed: {
 			bullets: new Set(bullets.map((b) => b.id)),
 			skills: new Set(skills.map((s) => s.id)),
-			fields: new Set(fields),
+			fields: new Set([...fields, 'baseSize', 'nameSize', 'headingSize', 'contactSize']),
 			bulletCounts: new Map(
 				bullets.map((target) => {
 					const entry =
@@ -209,6 +218,7 @@ export function validateEdits(raw: unknown, allowed: AllowedTargets): TailorEdit
 			kind !== 'rewrite_bullet' &&
 			kind !== 'remove_bullet' &&
 			kind !== 'rewrite_field' &&
+			kind !== 'set_font' &&
 			kind !== 'skill'
 		)
 			continue;
@@ -222,10 +232,24 @@ export function validateEdits(raw: unknown, allowed: AllowedTargets): TailorEdit
 
 		const trimmed = text.trim();
 		if (kind !== 'remove_bullet' && !trimmed) continue;
-		if ((kind === 'add_bullet' || kind === 'skill' || kind === 'rewrite_field') && bulletIndex !== -1) continue;
+		if (
+			(kind === 'add_bullet' || kind === 'skill' || kind === 'rewrite_field' || kind === 'set_font') &&
+			bulletIndex !== -1
+		)
+			continue;
 		if ((kind === 'rewrite_bullet' || kind === 'remove_bullet') && bulletIndex < 0) continue;
 
-		if (kind === 'rewrite_field') {
+		if (kind === 'set_font') {
+			const bounds: Record<string, [number, number]> = {
+				baseSize: [6, 14],
+				nameSize: [14, 32],
+				headingSize: [10, 24],
+				contactSize: [7, 16],
+			};
+			const value = Number(trimmed);
+			const range = bounds[targetId];
+			if (!range || !Number.isFinite(value) || value < range[0] || value > range[1]) continue;
+		} else if (kind === 'rewrite_field') {
 			if (!allowed.fields?.has(targetId)) continue;
 		} else {
 			const pool = kind === 'skill' ? allowed.skills : allowed.bullets;

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -96,7 +96,7 @@ export function buildTailorInput(
 			.join(', ')}`,
 		'',
 		isOverOnePage
-			? '=== LENGTH MODE ===\nThis resume is estimated to exceed one page. Do not add content unless it replaces more text. Prioritize concise rewrite_bullet edits and remove_bullet edits for generic, repetitive, or least relevant bullets until the resume is tighter.'
+			? '=== LENGTH MODE ===\nThe output must fit on exactly one side of one A4 page. This resume is estimated to exceed one page. Do not add content unless it replaces more text. Prioritize concise rewrites, removals, and font-size reductions for generic, repetitive, or least relevant content until it fits.'
 			: '=== LENGTH MODE ===\nThis resume is within the one-page target. Make concrete, grounded improvements; use add_bullet only when it adds job-relevant evidence not already stated.',
 		'',
 		'=== TARGETS: all resume entries (bullet kinds) ===',

--- a/web/src/lib/typst-generator.ts
+++ b/web/src/lib/typst-generator.ts
@@ -417,7 +417,7 @@ export function generateTypstCode(data: ResumeData): string {
     ]
   }
   if award != "" {
-    [ · #award]
+    [- #award]
   }
   v(-0.2em)
   if body != [] {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -134,7 +134,7 @@
 						class="mb-4 flex items-start justify-between gap-2 rounded border border-purple-300 bg-purple-50 px-3 py-2 text-sm text-purple-800"
 					>
 						<span
-							>The highlighted (purple) fields were filled in for you, by AI extraction or from O*NET — please review
+							>The highlighted (purple) fields were filled in for you, by AI extraction or from O*NET - please review
 							them for accuracy.</span
 						>
 						<button


### PR DESCRIPTION
## Summary

- Add AI tailoring support for resume-wide font-size adjustments.
- Guide overlong resumes toward exactly one A4 page.
- Validate and apply bounded font edits safely.
- Replace non-ASCII punctuation in user-facing text and generated Typst.

## Testing

- Added coverage for applying validated font-size adjustments.
- Not run: full test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tailoring can now adjust resume font sizes within supported limits.
  * Font-size changes are validated and highlighted for easier review.
  * Improved tailoring guidance includes current font settings and one-page fit considerations.

* **Style**
  * Standardized hyphen formatting across upload guidance, review messages, error text, and award headings.

* **Tests**
  * Added coverage confirming that valid font-size adjustments are applied and highlighted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->