### PR TITLE
fix: resolve all open bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,6 +54,15 @@ body:
       label: Relevant logs or screenshots
       description: Redact API keys, resume contents, names, email addresses, and other personal data.
       render: shell
+  - type: textarea
+    id: agent_attribution
+    attributes:
+      label: Agent attribution (AI submissions only)
+      description: If an AI agent prepared this issue, identify its actual provider, model, and harness.
+      placeholder: |
+        Agent provider: OpenAI
+        Agent model: gpt-5.6-sol
+        Agent harness: Codex
   - type: checkboxes
     id: checks
     attributes:
@@ -62,4 +71,6 @@ body:
         - label: I searched for an existing issue before filing this report.
           required: true
         - label: I removed credentials and personal resume data from this report.
+          required: true
+        - label: If an AI agent prepared this issue, I included its provider, model, and harness above.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,15 +54,6 @@ body:
       label: Relevant logs or screenshots
       description: Redact API keys, resume contents, names, email addresses, and other personal data.
       render: shell
-  - type: textarea
-    id: agent_attribution
-    attributes:
-      label: Agent attribution (AI submissions only)
-      description: If an AI agent prepared this issue, identify its actual provider, model, and harness.
-      placeholder: |
-        Agent provider: OpenAI
-        Agent model: gpt-5.6-sol
-        Agent harness: Codex
   - type: checkboxes
     id: checks
     attributes:
@@ -72,5 +63,16 @@ body:
           required: true
         - label: I removed credentials and personal resume data from this report.
           required: true
-        - label: If an AI agent prepared this issue, I included its provider, model, and harness above.
+        - label: If an AI agent prepared this issue, I will include its provider, model, and harness below.
           required: true
+  - type: textarea
+    id: agent_attribution
+    attributes:
+      label: Agent attribution
+      description: Enter the exact three-line footer for an AI submission. Otherwise enter "Not AI-generated".
+      placeholder: |
+        Agent provider: OpenAI
+        Agent model: gpt-5.6-sol
+        Agent harness: Codex
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,6 +23,15 @@ body:
     attributes:
       label: Alternatives considered
       description: Describe any workarounds or other approaches you considered.
+  - type: textarea
+    id: agent_attribution
+    attributes:
+      label: Agent attribution (AI submissions only)
+      description: If an AI agent prepared this issue, identify its actual provider, model, and harness.
+      placeholder: |
+        Agent provider: OpenAI
+        Agent model: gpt-5.6-sol
+        Agent harness: Codex
   - type: checkboxes
     id: impact
     attributes:
@@ -38,4 +47,6 @@ body:
       label: Before submitting
       options:
         - label: I searched for an existing issue or pull request covering this request.
+          required: true
+        - label: If an AI agent prepared this issue, I included its provider, model, and harness above.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,15 +23,6 @@ body:
     attributes:
       label: Alternatives considered
       description: Describe any workarounds or other approaches you considered.
-  - type: textarea
-    id: agent_attribution
-    attributes:
-      label: Agent attribution (AI submissions only)
-      description: If an AI agent prepared this issue, identify its actual provider, model, and harness.
-      placeholder: |
-        Agent provider: OpenAI
-        Agent model: gpt-5.6-sol
-        Agent harness: Codex
   - type: checkboxes
     id: impact
     attributes:
@@ -48,5 +39,16 @@ body:
       options:
         - label: I searched for an existing issue or pull request covering this request.
           required: true
-        - label: If an AI agent prepared this issue, I included its provider, model, and harness above.
+        - label: If an AI agent prepared this issue, I will include its provider, model, and harness below.
           required: true
+  - type: textarea
+    id: agent_attribution
+    attributes:
+      label: Agent attribution
+      description: Enter the exact three-line footer for an AI submission. Otherwise enter "Not AI-generated".
+      placeholder: |
+        Agent provider: OpenAI
+        Agent model: gpt-5.6-sol
+        Agent harness: Codex
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,6 @@
 - [ ] I updated relevant documentation.
 - [ ] I used synthetic test data and did not commit secrets or personal resume information.
 - [ ] I reviewed the diff for unrelated generated or formatting changes.
+- [ ] If an AI agent prepared this PR, I added its provider, model, and harness footer below.
+
+<!-- AI-authored PRs must end with: Agent provider, Agent model, and Agent harness. Remove this comment. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,4 +25,6 @@
 - [ ] I reviewed the diff for unrelated generated or formatting changes.
 - [ ] If an AI agent prepared this PR, I added its provider, model, and harness footer below.
 
-<!-- AI-authored PRs must end with: Agent provider, Agent model, and Agent harness. Remove this comment. -->
+AI assistance: no
+
+<!-- AI agents: change the declaration to "yes" and end the PR with Agent provider, Agent model, and Agent harness. -->

--- a/.github/scripts/check-agent-attribution.mjs
+++ b/.github/scripts/check-agent-attribution.mjs
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const FOOTER =
+  /(?:^|\r?\n)Agent provider: ([^\r\n<>]+)\r?\nAgent model: ([^\r\n<>]+)\r?\nAgent harness: ([^\r\n<>]+)\s*$/;
+const HUMAN_DECLARATION =
+  /(?:^|\r?\n)(?:AI assistance: no|Not AI-generated)\s*(?:\r?\n|$)/i;
+const AGENT_MARKER = /(?:^|\r?\n)Agent (?:provider|model|harness):/i;
+
+export function validateAttribution(body) {
+  if (typeof body !== "string")
+    return { valid: false, message: "Submission body is missing." };
+  const authoredBody = body.replace(
+    /\r?\n*<!-- This is an auto-generated comment: release notes by coderabbit\.ai -->[\s\S]*$/,
+    "",
+  );
+  const footer = FOOTER.exec(authoredBody);
+  if (footer) return { valid: true, message: "Valid AI attribution footer." };
+  if (AGENT_MARKER.test(authoredBody)) {
+    return {
+      valid: false,
+      message:
+        "AI attribution must be the exact provider/model/harness footer at the end of the submission.",
+    };
+  }
+  if (HUMAN_DECLARATION.test(authoredBody))
+    return { valid: true, message: "Submission declares no AI assistance." };
+  return {
+    valid: false,
+    message:
+      'Declare "AI assistance: no" (or "Not AI-generated" for an issue), or add the required AI footer.',
+  };
+}
+
+function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required.");
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const body = event.pull_request?.body ?? event.issue?.body;
+  const result = validateAttribution(body);
+  console.log(result.message);
+  if (!result.valid) process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/.github/scripts/check-agent-attribution.test.mjs
+++ b/.github/scripts/check-agent-attribution.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validateAttribution } from "./check-agent-attribution.mjs";
+
+describe("validateAttribution", () => {
+  it("accepts an exact footer at the end of an AI submission", () => {
+    assert.equal(
+      validateAttribution(
+        "Summary\n\nAgent provider: OpenAI\nAgent model: gpt-5.6-sol\nAgent harness: Codex",
+      ).valid,
+      true,
+    );
+  });
+
+  it("accepts GitHub bodies with CRLF line endings", () => {
+    assert.equal(
+      validateAttribution(
+        "Summary\r\n\r\nAgent provider: OpenAI\r\nAgent model: gpt-5.6-sol\r\nAgent harness: Codex\r\n",
+      ).valid,
+      true,
+    );
+  });
+
+  it("accepts an exact footer followed by CodeRabbit release notes", () => {
+    assert.equal(
+      validateAttribution(
+        "Summary\n\nAgent provider: OpenAI\nAgent model: gpt-5.6-sol\nAgent harness: Codex\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->\n\n## Summary by CodeRabbit\n\n- A generated note\n\n<!-- end of auto-generated comment: release notes by coderabbit.ai -->",
+      ).valid,
+      true,
+    );
+  });
+
+  it("rejects missing, partial, misplaced, and placeholder footers", () => {
+    assert.equal(validateAttribution("Summary only").valid, false);
+    assert.equal(
+      validateAttribution("Agent provider: OpenAI\nAgent model: gpt-5.6-sol")
+        .valid,
+      false,
+    );
+    assert.equal(
+      validateAttribution(
+        "Agent provider: OpenAI\nAgent model: gpt-5.6-sol\nAgent harness: Codex\nMore text",
+      ).valid,
+      false,
+    );
+    assert.equal(
+      validateAttribution(
+        "Agent provider: <provider>\nAgent model: <model>\nAgent harness: <harness>",
+      ).valid,
+      false,
+    );
+  });
+
+  it("accepts explicit human declarations", () => {
+    assert.equal(validateAttribution("AI assistance: no\n").valid, true);
+    assert.equal(
+      validateAttribution("### Agent attribution\n\nNot AI-generated\n").valid,
+      true,
+    );
+  });
+});

--- a/.github/scripts/check-commit-messages.mjs
+++ b/.github/scripts/check-commit-messages.mjs
@@ -12,7 +12,7 @@ const conventionalCommit =
 
 const git = (...args) =>
   execFileSync("git", args, { encoding: "utf8" }).trimEnd();
-const commits = git("rev-list", "--reverse", `${base}..${head}`)
+const commits = git("rev-list", "--no-merges", "--reverse", `${base}..${head}`)
   .split(/\r?\n/)
   .filter(Boolean);
 

--- a/.github/workflows/attribution.yml
+++ b/.github/workflows/attribution.yml
@@ -1,0 +1,22 @@
+name: Attribution
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request_target:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate AI attribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out validator
+        uses: actions/checkout@v4
+
+      - name: Validate submission declaration
+        run: node .github/scripts/check-agent-attribution.mjs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,3 +56,9 @@ jobs:
 
       - name: Run Svelte and TypeScript checks
         run: npm run check
+
+      - name: Check formatting
+        run: npm run lint
+
+      - name: Build production application
+        run: npm run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
           "${{ github.event.pull_request.base.sha }}"
           "${{ github.event.pull_request.head.sha }}"
 
+      - name: Test repository policy validators
+        run: node --test .github/scripts/check-agent-attribution.test.mjs
+
   test:
     name: Test and check
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,12 @@
 - Preserve unrelated user changes and keep commits focused.
 - Write every commit message as exactly one line in Conventional Commits format: `type(optional-scope): imperative description`. Allowed types are `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, and `revert`; add `!` before the colon for a breaking change. Do not add a commit-message body or footer.
 - Never push directly to `main`, even when the user explicitly requests it, always use the requested branch and pull-request workflow.
-- Pull requests submitted by an agent must end with an attribution footer that lists the actual provider and model used, using this exact format:
+- Issues and pull requests submitted by an agent must end with an attribution footer that lists the actual provider, model, and harness used, using this exact format:
 
   ```text
   Agent provider: <provider>
   Agent model: <model>
+  Agent harness: <harness>
   ```
 
 ## Architecture and deployment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,13 @@ node .github/scripts/check-commit-messages.mjs main HEAD
 - Include screenshots or recordings for meaningful UI changes.
 - Call out privacy, security, AI-cost, or Vercel deployment implications.
 - Respond to review comments with either a fix or a concise technical explanation.
+
+## AI agent attribution
+
+Any issue or pull request prepared by an AI agent must end with this footer, filled with the actual values used. The harness is the agent application or coding environment, such as Codex, Claude Code, or Cursor.
+
+```text
+Agent provider: <provider>
+Agent model: <model>
+Agent harness: <harness>
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,5 @@ Agent provider: <provider>
 Agent model: <model>
 Agent harness: <harness>
 ```
+
+Human-authored pull requests should retain `AI assistance: no` from the pull request template. Human-authored issues should enter `Not AI-generated` in the required attribution field. Repository automation validates either declaration and rejects partial or malformed AI footers.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A custom `.typ` file must implement the same `resume`, section-heading, and `ski
 
 The app replaces content after the marker with the resume generated from the form, then compiles the complete document in the browser before activating it. Typst templates are limited to 1 MB.
 
-Use [the example custom template](docs/examples/modern-teal.typ) or download the built-in template from the upload dialog as a starting point. DOCX templates are limited to 5 MB; their supported layout and style are converted into Typst, while Word-only effects and images may be approximated or omitted.
+Use [the example custom template](docs/examples/modern-teal.typ) or download the built-in template from the upload dialog as a starting point. DOCX templates are limited to 4 MB so multipart uploads remain below Vercel's request limit; their supported layout and style are converted into Typst, while Word-only effects and images may be approximated or omitted.
 
 ## Deployment
 

--- a/docs/examples/modern-teal.typ
+++ b/docs/examples/modern-teal.typ
@@ -79,14 +79,10 @@
 }
 
 #let period-worked(start-date, end-date) = {
-  let finish = if type(end-date) == str {
-    end-date
-  } else if end-date.year() == datetime.today().year() and end-date.month() == datetime.today().month() {
-    "Present"
-  } else {
-    end-date.display("[month repr:short] [year]")
-  }
-  [#start-date.display("[month repr:short] [year]") - #finish]
+  let display-date(value) = if type(value) == str { value } else { value.display("[month repr:short] [year]") }
+  let start = display-date(start-date)
+  let finish = display-date(end-date)
+  if start == "" { finish } else if finish == "" { start } else { [#start - #finish] }
 }
 
 #let work-heading(title, company, location, start-date, end-date, body) = {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2623,9 +2623,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.13",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+			"integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
 				"@tailwindcss/postcss": "^4.1.18",
 				"@tailwindcss/typography": "^0.5.19",
 				"@tailwindcss/vite": "^4.1.18",
+				"@types/node": "^22.20.2",
 				"autoprefixer": "^10.4.24",
 				"postcss": "^8.5.6",
 				"prettier": "^3.8.3",
@@ -2472,6 +2473,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "22.20.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+			"integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
 		"node_modules/@vercel/nft": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.3.0.tgz",
@@ -4369,6 +4381,13 @@
 			"version": "1.13.8",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
 			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
 		"@tailwindcss/postcss": "^4.1.18",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.1.18",
+		"@types/node": "^22.20.2",
 		"autoprefixer": "^10.4.24",
 		"postcss": "^8.5.6",
 		"prettier": "^3.8.3",

--- a/web/src/lib/browser-download.test.ts
+++ b/web/src/lib/browser-download.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { downloadBlob } from './browser-download';
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe('downloadBlob', () => {
+	it('clicks an attached anchor before revoking its URL later', () => {
+		vi.useFakeTimers();
+		const events: string[] = [];
+		const anchor = {
+			href: '',
+			download: '',
+			hidden: false,
+			click: () => events.push('click'),
+			remove: () => events.push('remove'),
+		};
+		vi.stubGlobal('URL', {
+			createObjectURL: () => 'blob:test',
+			revokeObjectURL: () => events.push('revoke'),
+		});
+		vi.stubGlobal('document', {
+			createElement: () => anchor,
+			body: { appendChild: () => events.push('append') },
+		});
+
+		downloadBlob(new Blob(['resume']), 'resume.pdf');
+		expect(events).toEqual(['append', 'click', 'remove']);
+		expect(anchor.href).toBe('blob:test');
+		expect(anchor.download).toBe('resume.pdf');
+		vi.runAllTimers();
+		expect(events).toEqual(['append', 'click', 'remove', 'revoke']);
+	});
+});

--- a/web/src/lib/browser-download.ts
+++ b/web/src/lib/browser-download.ts
@@ -1,0 +1,14 @@
+const REVOKE_DELAY_MS = 1_000;
+
+/** Starts a browser download and keeps its object URL alive long enough for asynchronous consumers. */
+export function downloadBlob(blob: Blob, filename: string): void {
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = filename;
+	anchor.hidden = true;
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	setTimeout(() => URL.revokeObjectURL(url), REVOKE_DELAY_MS);
+}

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -331,11 +331,7 @@
 						purple so you can reword it.
 					</p>
 
-					<button
-						class="primary mt-3 w-full text-sm disabled:opacity-60"
-						onclick={autoTailor}
-						disabled={tailoring}
-					>
+					<button class="primary mt-3 w-full text-sm disabled:opacity-60" onclick={autoTailor} disabled={tailoring}>
 						{tailoring ? 'Tailoring...' : 'Auto-tailor with AI'}
 					</button>
 					<p class="mt-1 text-xs text-gray-500">

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -119,7 +119,7 @@
 		menuFor = null;
 	}
 
-	function insertBullet(kind: 'experience' | 'project', id: string, text: string) {
+	function insertBullet(kind: 'experience' | 'project' | 'education' | 'leadership', id: string, text: string) {
 		const result = appendBullet(data, kind, id, text);
 		data = result.data;
 		applyPaths([result.path]);
@@ -296,7 +296,7 @@
 					<button
 						class="primary mt-3 w-full text-sm disabled:opacity-60"
 						onclick={autoTailor}
-						disabled={tailoring || bulletDests.length + skillDests.length === 0}
+						disabled={tailoring}
 					>
 						{tailoring ? 'Tailoring...' : 'Auto-tailor with AI'}
 					</button>

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { fly, fade } from 'svelte/transition';
 	import { onetStore } from '$lib/onet-store';
 	import { onetSectionLabels } from '$lib/onet-types';
@@ -29,8 +30,17 @@
 	let tailorError = $state('');
 	let tailorNote = $state('');
 	let searchTimer: ReturnType<typeof setTimeout> | undefined;
+	let drawer = $state<HTMLElement>();
+	let searchInput = $state<HTMLInputElement>();
 
 	const GENERIC_ERROR = "Can't reach O*NET. Check your connection and retry.";
+
+	$effect(() => {
+		if (!open) return;
+		const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		void tick().then(() => (searchInput ?? drawer)?.focus());
+		return () => opener?.focus();
+	});
 
 	async function readError(res: Response): Promise<string> {
 		try {
@@ -200,7 +210,31 @@
 	}
 
 	function onKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape') close();
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			close();
+			return;
+		}
+		if (e.key !== 'Tab' || !drawer) return;
+		const focusable = Array.from(
+			drawer.querySelectorAll<HTMLElement>(
+				'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+			),
+		).filter((element) => !element.hasAttribute('hidden'));
+		if (focusable.length === 0) {
+			e.preventDefault();
+			drawer.focus();
+			return;
+		}
+		const first = focusable[0];
+		const last = focusable.at(-1)!;
+		if (e.shiftKey && (document.activeElement === first || document.activeElement === drawer)) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
 	}
 
 	// Bullet-shaped sections (tasks, work activities) go into experience or
@@ -223,19 +257,22 @@
 	];
 </script>
 
-<svelte:window onkeydown={onKeydown} />
-
 {#if open}
 	<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
 	<div class="fixed inset-0 z-40 bg-black/30" transition:fade={{ duration: 150 }} onclick={close}></div>
 
-	<aside
+	<div
+		bind:this={drawer}
 		class="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-2xl"
 		transition:fly={{ x: 400, duration: 200 }}
-		aria-label="Tailor to a job"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="tailor-dialog-title"
+		tabindex="-1"
+		onkeydown={onKeydown}
 	>
 		<div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-			<h2 class="text-lg font-semibold">Tailor to a job</h2>
+			<h2 id="tailor-dialog-title" class="text-lg font-semibold">Tailor to a job</h2>
 			<button class="secondary px-2 py-1 text-sm" onclick={close} aria-label="Close">X</button>
 		</div>
 
@@ -243,6 +280,7 @@
 			{#if !occupation}
 				<label for="onet-search">Search O*NET occupations</label>
 				<input
+					bind:this={searchInput}
 					id="onet-search"
 					type="text"
 					bind:value={query}
@@ -444,5 +482,5 @@
 			>
 			(USDOL/ETA), CC BY 4.0.
 		</p>
-	</aside>
+	</div>
 {/if}

--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -38,8 +38,13 @@
 	$effect(() => {
 		if (!open) return;
 		const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-		void tick().then(() => (searchInput ?? drawer)?.focus());
 		return () => opener?.focus();
+	});
+
+	$effect(() => {
+		if (!open) return;
+		const showingOccupation = occupation !== null;
+		void tick().then(() => (showingOccupation ? drawer : (searchInput ?? drawer))?.focus());
 	});
 
 	async function readError(res: Response): Promise<string> {

--- a/web/src/lib/components/PreviewPanel.svelte
+++ b/web/src/lib/components/PreviewPanel.svelte
@@ -20,7 +20,7 @@
 	class="bg-gray-500 rounded-lg shadow p-4 flex flex-col items-center overflow-auto max-h-[calc(100vh-10rem)] lg:max-h-none lg:h-full"
 >
 	<h2 class="text-lg font-semibold mb-4 text-white">
-		{showCode ? 'Typst Code' : 'Resume Preview (8.5" x 11")'}
+		{showCode ? 'Typst Code' : 'Resume Preview'}
 	</h2>
 
 	{#if showCode}

--- a/web/src/lib/components/TemplateModal.svelte
+++ b/web/src/lib/components/TemplateModal.svelte
@@ -8,6 +8,7 @@
 		type CustomTemplate,
 	} from '$lib/template-store';
 	import type { ResumeData } from '$lib/types';
+	import { DOCX_TEMPLATE_MAX_BYTES, DOCX_TEMPLATE_MAX_LABEL } from '$lib/template-limits';
 
 	let {
 		open = $bindable(),
@@ -54,7 +55,9 @@
 			const isDocx = lowerName.endsWith('.docx');
 			if (!isTypst && !isDocx) throw new Error('Choose a Typst (.typ) or Word (.docx) template.');
 			if (isTypst && file.size > MAX_TEMPLATE_SIZE) throw new Error('The Typst template must be 1 MB or smaller.');
-			if (isDocx && file.size > 5 * 1024 * 1024) throw new Error('The DOCX template must be 5 MB or smaller.');
+			if (isDocx && file.size > DOCX_TEMPLATE_MAX_BYTES) {
+				throw new Error(`The DOCX template must be ${DOCX_TEMPLATE_MAX_LABEL} or smaller.`);
+			}
 
 			let template: CustomTemplate;
 			if (isDocx) {
@@ -222,7 +225,7 @@
 					<span class="text-gray-700">Validating and compiling template...</span>
 				{:else}
 					<span class="text-gray-600">Drag a .typ or .docx file here, or click to browse</span>
-					<span class="mt-1 block text-xs text-gray-400">Typst max 1 MB; Word max 5 MB</span>
+					<span class="mt-1 block text-xs text-gray-400">Typst max 1 MB; Word max {DOCX_TEMPLATE_MAX_LABEL}</span>
 				{/if}
 			</button>
 			<input

--- a/web/src/lib/components/TemplateModal.svelte
+++ b/web/src/lib/components/TemplateModal.svelte
@@ -9,6 +9,7 @@
 	} from '$lib/template-store';
 	import type { ResumeData } from '$lib/types';
 	import { DOCX_TEMPLATE_MAX_BYTES, DOCX_TEMPLATE_MAX_LABEL } from '$lib/template-limits';
+	import { downloadBlob } from '$lib/browser-download';
 
 	let {
 		open = $bindable(),
@@ -116,12 +117,7 @@
 
 	function downloadStarterTemplate() {
 		const blob = new Blob([generateTypstCode(data)], { type: 'text/plain;charset=utf-8' });
-		const url = URL.createObjectURL(blob);
-		const anchor = document.createElement('a');
-		anchor.href = url;
-		anchor.download = 'resume-template.typ';
-		anchor.click();
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, 'resume-template.typ');
 	}
 
 	function onDialogKeydown(event: KeyboardEvent) {

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -106,6 +106,41 @@ describe('applyTailorEdits', () => {
 		expect(removed).toBe(1);
 	});
 
+	it('deduplicates removals that resolve to the same original bullet', () => {
+		const before = seed();
+		before.workExperience[0].bullets = ['A', 'B'];
+		const { data, removed } = applyTailorEdits(before, [
+			{ kind: 'remove_bullet', targetId: 'w1', bulletIndex: 0, text: '' },
+			{ kind: 'remove_bullet', targetId: 'w1', bulletIndex: 0, text: 'duplicate rationale' },
+		]);
+
+		expect(data.workExperience[0].bullets).toEqual(['B']);
+		expect(removed).toBe(1);
+	});
+
+	it('rewrites education bullets using their original indices', () => {
+		const before = seed();
+		before.education = [
+			{
+				id: 'e1',
+				institution: 'State University',
+				location: '',
+				degree: 'BS',
+				major: '',
+				startDate: '',
+				endDate: '',
+				isPresent: false,
+				bullets: ['Original'],
+			},
+		];
+		const { data, paths } = applyTailorEdits(before, [
+			{ kind: 'rewrite_bullet', targetId: 'e1', bulletIndex: 0, text: 'Rewritten' },
+		]);
+
+		expect(data.education[0].bullets).toEqual(['Rewritten']);
+		expect(paths).toEqual(['education.0.bullets.0']);
+	});
+
 	it('routes a bullet to an education entry', () => {
 		const before = seed();
 		before.education = [

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -106,6 +106,27 @@ describe('applyTailorEdits', () => {
 		expect(removed).toBe(1);
 	});
 
+	it('routes a bullet to an education entry', () => {
+		const before = seed();
+		before.education = [
+			{
+				id: 'e1',
+				institution: 'State University',
+				location: '',
+				degree: 'BS',
+				major: '',
+				startDate: '',
+				endDate: '',
+				isPresent: false,
+				bullets: [],
+			},
+		];
+		const { data, paths } = applyTailorEdits(before, [bullet('e1', 'Completed relevant coursework.')]);
+
+		expect(data.education[0].bullets).toEqual(['Completed relevant coursework.']);
+		expect(paths).toEqual(['education.0.bullets.0']);
+	});
+
 	it('resolves rewrites against the original snapshot when an earlier bullet is removed', () => {
 		const before = seed();
 		before.workExperience[0].bullets = ['A', 'B', 'C'];

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -106,6 +106,29 @@ describe('applyTailorEdits', () => {
 		expect(removed).toBe(1);
 	});
 
+	it('resolves rewrites against the original snapshot when an earlier bullet is removed', () => {
+		const before = seed();
+		before.workExperience[0].bullets = ['A', 'B', 'C'];
+		const { data, paths } = applyTailorEdits(before, [
+			{ kind: 'remove_bullet', targetId: 'w1', bulletIndex: 0, text: '' },
+			{ kind: 'rewrite_bullet', targetId: 'w1', bulletIndex: 1, text: 'B2' },
+		]);
+
+		expect(data.workExperience[0].bullets).toEqual(['B2', 'C']);
+		expect(paths).toEqual(['workExperience.0.bullets.0']);
+	});
+
+	it('maps filtered prompt indices back to the original bullet array', () => {
+		const before = seed();
+		before.workExperience[0].bullets = ['A', '', 'C'];
+		const { data, paths } = applyTailorEdits(before, [
+			{ kind: 'rewrite_bullet', targetId: 'w1', bulletIndex: 1, text: 'C2' },
+		]);
+
+		expect(data.workExperience[0].bullets).toEqual(['A', '', 'C2']);
+		expect(paths).toEqual(['workExperience.0.bullets.2']);
+	});
+
 	it('applies a validated font size adjustment', () => {
 		const { data, paths } = applyTailorEdits(seed(), [
 			{ kind: 'set_font', targetId: 'baseSize', bulletIndex: -1, text: '8.1' },

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -13,9 +13,26 @@ export function applyTailorEdits(
 ): { data: ResumeData; paths: string[]; removed: number } {
 	let next = data;
 	const paths: string[] = [];
+	const bulletHighlights: { targetId: string; index: number }[] = [];
 	let removed = 0;
+	const bulletPositions = new Map<string, number[]>();
 
-	for (const edit of edits) {
+	for (const entries of [data.workExperience, data.projects, data.education, data.leadership]) {
+		for (const entry of entries) {
+			bulletPositions.set(
+				entry.id,
+				entry.bullets.flatMap((bullet, index) => (bullet ? [index] : [])),
+			);
+		}
+	}
+
+	const removals = edits
+		.filter((edit) => edit.kind === 'remove_bullet')
+		.map((edit) => ({ ...edit, originalIndex: bulletPositions.get(edit.targetId)?.[edit.bulletIndex] }))
+		.filter((edit): edit is typeof edit & { originalIndex: number } => edit.originalIndex !== undefined)
+		.sort((a, b) => (a.targetId === b.targetId ? b.originalIndex - a.originalIndex : 0));
+
+	for (const edit of edits.filter((item) => item.kind !== 'remove_bullet')) {
 		if (edit.kind === 'set_font') {
 			const key = edit.targetId as keyof ResumeData['fonts'];
 			if (!(key in next.fonts)) continue;
@@ -67,7 +84,10 @@ export function applyTailorEdits(
 			if (!target) continue;
 			const result = appendBullet(next, target.kind, edit.targetId, edit.text);
 			next = result.data;
-			if (result.path) paths.push(result.path);
+			if (result.path) {
+				const index = Number(result.path.split('.').at(-1));
+				bulletHighlights.push({ targetId: edit.targetId, index });
+			}
 			continue;
 		}
 
@@ -83,24 +103,57 @@ export function applyTailorEdits(
 		const entries = next[key];
 		const entryIndex = entries.findIndex((entry) => entry.id === edit.targetId);
 		const entry = entries[entryIndex];
-		if (!entry || edit.bulletIndex < 0 || edit.bulletIndex >= entry.bullets.length) continue;
+		const originalIndex = bulletPositions.get(edit.targetId)?.[edit.bulletIndex];
+		if (!entry || originalIndex === undefined || originalIndex >= entry.bullets.length) continue;
 
-		if (edit.kind === 'remove_bullet') {
-			const updated = [...entries];
-			updated[entryIndex] = { ...entry, bullets: entry.bullets.filter((_, index) => index !== edit.bulletIndex) };
-			next = { ...next, [key]: updated };
-			removed++;
-			continue;
-		}
-
-		if (edit.kind !== 'rewrite_bullet' || entry.bullets[edit.bulletIndex] === edit.text) continue;
+		if (edit.kind !== 'rewrite_bullet' || entry.bullets[originalIndex] === edit.text) continue;
 		const updated = [...entries];
 		updated[entryIndex] = {
 			...entry,
-			bullets: entry.bullets.map((bullet, index) => (index === edit.bulletIndex ? edit.text : bullet)),
+			bullets: entry.bullets.map((bullet, index) => (index === originalIndex ? edit.text : bullet)),
 		};
 		next = { ...next, [key]: updated };
-		paths.push(`${key}.${entryIndex}.bullets.${edit.bulletIndex}`);
+		bulletHighlights.push({ targetId: edit.targetId, index: originalIndex });
+	}
+
+	for (const edit of removals) {
+		const target = bulletTargets(next).find((item) => item.id === edit.targetId);
+		const other =
+			next.education.find((entry) => entry.id === edit.targetId) ??
+			next.leadership.find((entry) => entry.id === edit.targetId);
+		if (!target && !other) continue;
+		const key = target
+			? target.kind === 'experience'
+				? 'workExperience'
+				: 'projects'
+			: next.education.some((entry) => entry.id === edit.targetId)
+				? 'education'
+				: 'leadership';
+		const entries = next[key];
+		const entryIndex = entries.findIndex((entry) => entry.id === edit.targetId);
+		const entry = entries[entryIndex];
+		if (!entry || edit.originalIndex >= entry.bullets.length) continue;
+		const updated = [...entries];
+		updated[entryIndex] = {
+			...entry,
+			bullets: entry.bullets.filter((_, index) => index !== edit.originalIndex),
+		};
+		next = { ...next, [key]: updated };
+		removed++;
+	}
+
+	for (const highlight of bulletHighlights) {
+		if (removals.some((edit) => edit.targetId === highlight.targetId && edit.originalIndex === highlight.index)) {
+			continue;
+		}
+		const target = bulletTargets(next).find((item) => item.id === highlight.targetId);
+		if (!target) continue;
+		const key = target.kind === 'experience' ? 'workExperience' : 'projects';
+		const entryIndex = next[key].findIndex((entry) => entry.id === highlight.targetId);
+		const shift = removals.filter(
+			(edit) => edit.targetId === highlight.targetId && edit.originalIndex < highlight.index,
+		).length;
+		paths.push(`${key}.${entryIndex}.bullets.${highlight.index - shift}`);
 	}
 
 	return { data: next, paths, removed };

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -125,7 +125,9 @@ export function applyTailorEdits(
 		const key = target
 			? target.kind === 'experience'
 				? 'workExperience'
-				: 'projects'
+				: target.kind === 'project'
+					? 'projects'
+					: target.kind
 			: next.education.some((entry) => entry.id === edit.targetId)
 				? 'education'
 				: 'leadership';
@@ -148,7 +150,8 @@ export function applyTailorEdits(
 		}
 		const target = bulletTargets(next).find((item) => item.id === highlight.targetId);
 		if (!target) continue;
-		const key = target.kind === 'experience' ? 'workExperience' : 'projects';
+		const key =
+			target.kind === 'experience' ? 'workExperience' : target.kind === 'project' ? 'projects' : target.kind;
 		const entryIndex = next[key].findIndex((entry) => entry.id === highlight.targetId);
 		const shift = removals.filter(
 			(edit) => edit.targetId === highlight.targetId && edit.originalIndex < highlight.index,

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -150,8 +150,7 @@ export function applyTailorEdits(
 		}
 		const target = bulletTargets(next).find((item) => item.id === highlight.targetId);
 		if (!target) continue;
-		const key =
-			target.kind === 'experience' ? 'workExperience' : target.kind === 'project' ? 'projects' : target.kind;
+		const key = target.kind === 'experience' ? 'workExperience' : target.kind === 'project' ? 'projects' : target.kind;
 		const entryIndex = next[key].findIndex((entry) => entry.id === highlight.targetId);
 		const shift = removals.filter(
 			(edit) => edit.targetId === highlight.targetId && edit.originalIndex < highlight.index,

--- a/web/src/lib/onet-apply.ts
+++ b/web/src/lib/onet-apply.ts
@@ -26,11 +26,17 @@ export function applyTailorEdits(
 		}
 	}
 
-	const removals = edits
-		.filter((edit) => edit.kind === 'remove_bullet')
-		.map((edit) => ({ ...edit, originalIndex: bulletPositions.get(edit.targetId)?.[edit.bulletIndex] }))
-		.filter((edit): edit is typeof edit & { originalIndex: number } => edit.originalIndex !== undefined)
-		.sort((a, b) => (a.targetId === b.targetId ? b.originalIndex - a.originalIndex : 0));
+	const removals = new Map<string, TailorEdit & { kind: 'remove_bullet'; originalIndex: number }>();
+	for (const edit of edits) {
+		if (edit.kind !== 'remove_bullet') continue;
+		const originalIndex = bulletPositions.get(edit.targetId)?.[edit.bulletIndex];
+		if (originalIndex === undefined) continue;
+		removals.set(`${edit.targetId}:${originalIndex}`, { ...edit, kind: 'remove_bullet', originalIndex });
+	}
+	const sortedRemovals = [...removals.values()].sort((a, b) =>
+		a.targetId === b.targetId ? b.originalIndex - a.originalIndex : 0,
+	);
+	const appliedRemovals: typeof sortedRemovals = [];
 
 	for (const edit of edits.filter((item) => item.kind !== 'remove_bullet')) {
 		if (edit.kind === 'set_font') {
@@ -94,7 +100,9 @@ export function applyTailorEdits(
 		const key = target
 			? target.kind === 'experience'
 				? 'workExperience'
-				: 'projects'
+				: target.kind === 'project'
+					? 'projects'
+					: target.kind
 			: other
 				? next.education.some((e) => e.id === other.id)
 					? 'education'
@@ -116,7 +124,7 @@ export function applyTailorEdits(
 		bulletHighlights.push({ targetId: edit.targetId, index: originalIndex });
 	}
 
-	for (const edit of removals) {
+	for (const edit of sortedRemovals) {
 		const target = bulletTargets(next).find((item) => item.id === edit.targetId);
 		const other =
 			next.education.find((entry) => entry.id === edit.targetId) ??
@@ -142,17 +150,20 @@ export function applyTailorEdits(
 		};
 		next = { ...next, [key]: updated };
 		removed++;
+		appliedRemovals.push(edit);
 	}
 
 	for (const highlight of bulletHighlights) {
-		if (removals.some((edit) => edit.targetId === highlight.targetId && edit.originalIndex === highlight.index)) {
+		if (
+			appliedRemovals.some((edit) => edit.targetId === highlight.targetId && edit.originalIndex === highlight.index)
+		) {
 			continue;
 		}
 		const target = bulletTargets(next).find((item) => item.id === highlight.targetId);
 		if (!target) continue;
 		const key = target.kind === 'experience' ? 'workExperience' : target.kind === 'project' ? 'projects' : target.kind;
 		const entryIndex = next[key].findIndex((entry) => entry.id === highlight.targetId);
-		const shift = removals.filter(
+		const shift = appliedRemovals.filter(
 			(edit) => edit.targetId === highlight.targetId && edit.originalIndex < highlight.index,
 		).length;
 		paths.push(`${key}.${entryIndex}.bullets.${highlight.index - shift}`);

--- a/web/src/lib/onet-insert.ts
+++ b/web/src/lib/onet-insert.ts
@@ -5,7 +5,7 @@ import { generateId } from './resume-utils';
 // ResumeData plus the dotted field path(s) to highlight, and the caller assigns
 // the result. A null path means nothing changed.
 
-export type BulletTargetKind = 'experience' | 'project';
+export type BulletTargetKind = 'experience' | 'project' | 'education' | 'leadership';
 
 export interface BulletTarget {
 	id: string;
@@ -29,7 +29,17 @@ export function bulletTargets(data: ResumeData): BulletTarget[] {
 		kind: 'project' as const,
 		label: p.name || 'Untitled project',
 	}));
-	return [...experience, ...projects];
+	const education = data.education.map((entry) => ({
+		id: entry.id,
+		kind: 'education' as const,
+		label: [entry.degree, entry.institution].filter(Boolean).join(' at ') || 'Untitled education',
+	}));
+	const leadership = data.leadership.map((entry) => ({
+		id: entry.id,
+		kind: 'leadership' as const,
+		label: [entry.title, entry.organization].filter(Boolean).join(' at ') || 'Untitled leadership',
+	}));
+	return [...experience, ...projects, ...education, ...leadership];
 }
 
 export function skillTargets(data: ResumeData): SkillTarget[] {
@@ -42,7 +52,14 @@ export function appendBullet(
 	id: string,
 	text: string,
 ): { data: ResumeData; path: string | null } {
-	const key = kind === 'experience' ? 'workExperience' : 'projects';
+	const key =
+		kind === 'experience'
+			? 'workExperience'
+			: kind === 'project'
+				? 'projects'
+				: kind === 'education'
+					? 'education'
+					: 'leadership';
 	const entries = data[key];
 	const index = entries.findIndex((e) => e.id === id);
 	if (index === -1) return { data, path: null };

--- a/web/src/lib/pdf-compiler.ts
+++ b/web/src/lib/pdf-compiler.ts
@@ -1,4 +1,5 @@
 import { $typst } from '@myriaddreamin/typst.ts';
+import { downloadBlob } from './browser-download';
 
 let initPromise: Promise<void> | null = null;
 let initError: Error | null = null;
@@ -58,10 +59,5 @@ export async function compileToSvg(typstCode: string): Promise<string> {
 
 export function downloadPdf(pdfData: Uint8Array, filename: string = 'resume.pdf'): void {
 	const blob = new Blob([new Uint8Array(pdfData)], { type: 'application/pdf' });
-	const url = URL.createObjectURL(blob);
-	const a = document.createElement('a');
-	a.href = url;
-	a.download = filename;
-	a.click();
-	URL.revokeObjectURL(url);
+	downloadBlob(blob, filename);
 }

--- a/web/src/lib/server/bounded-body.test.ts
+++ b/web/src/lib/server/bounded-body.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readBoundedBody, RequestBodyTooLargeError } from './bounded-body';
+
+describe('readBoundedBody', () => {
+	it('preserves a UTF-8 body split across chunks', async () => {
+		const bytes = new TextEncoder().encode('{"name":"résumé"}');
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(bytes.slice(0, 11));
+				controller.enqueue(bytes.slice(11));
+				controller.close();
+			},
+		});
+		const request = new Request('https://example.test', {
+			method: 'POST',
+			body: stream,
+			duplex: 'half',
+		} as RequestInit);
+		expect(await readBoundedBody(request, bytes.length)).toBe('{"name":"résumé"}');
+	});
+
+	it('cancels an oversized stream as soon as the limit is exceeded', async () => {
+		const cancel = vi.fn();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(6));
+				controller.enqueue(new Uint8Array(6));
+			},
+			cancel,
+		});
+		const request = new Request('https://example.test', {
+			method: 'POST',
+			body: stream,
+			duplex: 'half',
+		} as RequestInit);
+
+		await expect(readBoundedBody(request, 10)).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+		expect(cancel).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/lib/server/bounded-body.ts
+++ b/web/src/lib/server/bounded-body.ts
@@ -1,0 +1,26 @@
+export class RequestBodyTooLargeError extends Error {}
+
+/** Reads a request body while enforcing its byte ceiling before buffering the full payload. */
+export async function readBoundedBody(request: Request, maxBytes: number): Promise<string> {
+	if (!request.body) return '';
+	const reader = request.body.getReader();
+	const decoder = new TextDecoder();
+	let size = 0;
+	let text = '';
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			size += value.byteLength;
+			if (size > maxBytes) {
+				await reader.cancel().catch(() => undefined);
+				throw new RequestBodyTooLargeError(`Request body exceeds ${maxBytes} bytes.`);
+			}
+			text += decoder.decode(value, { stream: true });
+		}
+		return text + decoder.decode();
+	} finally {
+		reader.releaseLock();
+	}
+}

--- a/web/src/lib/server/extraction.test.ts
+++ b/web/src/lib/server/extraction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapOpenAIError, RESUME_SCHEMA } from './extraction';
+import { EXTRACTION_PROMPT, mapOpenAIError, RESUME_SCHEMA, validateExtractedResume } from './extraction';
 
 describe('mapOpenAIError', () => {
 	it('maps insufficient_quota 429 to quota_exceeded', () => {
@@ -52,5 +52,33 @@ describe('RESUME_SCHEMA clearance field', () => {
 			'Public Trust',
 		]);
 		expect(clearanceItems.properties.status.enum).toEqual(['Active', 'Inactive', 'Eligible']);
+	});
+});
+
+describe('extraction output safety', () => {
+	const valid = {
+		personalInfo: { name: 'Ada', phone: '', location: '', email: '', website: '', linkedin: '', github: '' },
+		profile: { summary: '' },
+		education: [],
+		projects: [],
+		workExperience: [],
+		leadership: [],
+		skills: [],
+		achievements: [],
+		clearance: [],
+	};
+
+	it('forbids guessed contact data without contradictory exceptions', () => {
+		expect(EXTRACTION_PROMPT).toContain('Do not invent, guess, or derive');
+		expect(EXTRACTION_PROMPT).not.toContain('reasonably infer');
+	});
+
+	it('accepts a complete schema-shaped extraction', () => {
+		expect(validateExtractedResume(valid)).toEqual(valid);
+	});
+
+	it('rejects missing or incorrectly typed model fields', () => {
+		expect(validateExtractedResume({ ...valid, skills: [{ category: 'Tools', skills: 42 }] })).toBeNull();
+		expect(validateExtractedResume({ ...valid, personalInfo: { name: 'Ada' } })).toBeNull();
 	});
 });

--- a/web/src/lib/server/extraction.ts
+++ b/web/src/lib/server/extraction.ts
@@ -1,3 +1,5 @@
+import type { ExtractedResume } from '$lib/types';
+
 export const MODEL = 'gpt-5.6-luna';
 
 export type ExtractErrorCode =
@@ -62,10 +64,8 @@ export const EXTRACTION_PROMPT = [
 	'Format dates as "YYYY-MM" when a month and year are available; otherwise use "YYYY" or an empty string.',
 	'Set isPresent to true only when the resume says a role/study is ongoing (e.g. "Present", "Current").',
 	'For linkedin and github, return just the username/handle, not the full URL.',
-	'Do not invent or infer data that is not in the resume.',
-	'You can try to fill in sections with data from other sections if the information is clearly relevant (e.g. a project mentioned in a work experience bullet).',
-	'In fact, do your best to fill in as much of the schema as possible, but never fabricate details. If you can reasonably infer a detail (e.g. a linkedin URL from a name), you may do so, but be conservative and prioritize accuracy over completeness.',
-	'Do try to complete the schema as much as possible using any relevant information in the resume, but do not fabricate details that are not explicitly stated or very clearly implied. If you can reasonably infer a detail (e.g. a linkedin URL from a name), you may do so, but be conservative and prioritize accuracy over completeness.',
+	'Do not invent, guess, or derive any value that is not explicitly present in the resume, especially contact details and profile URLs.',
+	'You may organize explicitly stated facts into the most appropriate section, but do not add new facts while doing so.',
 ].join(' ');
 
 const stringArray = { type: 'array', items: { type: 'string' } } as const;
@@ -216,3 +216,58 @@ export const RESUME_SCHEMA = {
 		},
 	},
 } as const;
+
+function record(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasFields(value: unknown, strings: string[], booleans: string[] = []): boolean {
+	return (
+		record(value) &&
+		strings.every((key) => typeof value[key] === 'string') &&
+		booleans.every((key) => typeof value[key] === 'boolean')
+	);
+}
+
+function hasEntries(value: unknown, strings: string[], booleans: string[] = [], bullets = false): boolean {
+	return (
+		Array.isArray(value) &&
+		value.every(
+			(item) =>
+				hasFields(item, strings, booleans) &&
+				(!bullets ||
+					(Array.isArray((item as Record<string, unknown>).bullets) &&
+						((item as Record<string, unknown>).bullets as unknown[]).every((bullet) => typeof bullet === 'string'))),
+		)
+	);
+}
+
+/** Validates parsed structured output before it reaches the browser. */
+export function validateExtractedResume(value: unknown): ExtractedResume | null {
+	if (!record(value)) return null;
+	if (
+		!hasFields(value.personalInfo, ['name', 'phone', 'location', 'email', 'website', 'linkedin', 'github']) ||
+		!hasFields(value.profile, ['summary']) ||
+		!hasEntries(
+			value.education,
+			['institution', 'location', 'degree', 'major', 'startDate', 'endDate'],
+			['isPresent'],
+			true,
+		) ||
+		!hasEntries(value.projects, ['name', 'stack', 'url', 'award'], [], true) ||
+		!hasEntries(value.workExperience, ['title', 'company', 'location', 'startDate', 'endDate'], ['isPresent'], true) ||
+		!hasEntries(value.leadership, ['title', 'organization', 'location', 'startDate', 'endDate'], ['isPresent'], true) ||
+		!hasEntries(value.skills, ['category', 'skills']) ||
+		!hasEntries(value.achievements, ['title', 'date', 'description']) ||
+		!hasEntries(value.clearance, ['level', 'status', 'dateGranted'])
+	) {
+		return null;
+	}
+
+	const validClearance = (value.clearance as Record<string, unknown>[]).every(
+		(entry) =>
+			['Confidential', 'Secret', 'Top Secret', 'Top Secret/SCI', 'Public Trust'].includes(entry.level as string) &&
+			['Active', 'Inactive', 'Eligible'].includes(entry.status as string),
+	);
+	return validClearance ? (value as unknown as ExtractedResume) : null;
+}

--- a/web/src/lib/server/onet.ts
+++ b/web/src/lib/server/onet.ts
@@ -13,7 +13,15 @@ const BASE = 'https://api-v2.onetcenter.org';
 // Sections are paginated with a default window of 20. Ask for the whole list.
 const PAGE_END = 100;
 
-export type OnetErrorCode = 'invalid_code' | 'not_found' | 'rate_limited' | 'auth' | 'upstream_unavailable' | 'unknown';
+export type OnetErrorCode =
+	| 'invalid_code'
+	| 'invalid_request'
+	| 'invalid_query'
+	| 'not_found'
+	| 'rate_limited'
+	| 'auth'
+	| 'upstream_unavailable'
+	| 'unknown';
 
 export interface OnetError {
 	code: OnetErrorCode;
@@ -23,6 +31,8 @@ export interface OnetError {
 
 const MESSAGES: Record<OnetErrorCode, string> = {
 	invalid_code: "That job code isn't valid.",
+	invalid_request: "That resume request isn't valid.",
+	invalid_query: 'That search keyword is too long.',
 	not_found: 'No O*NET data for that occupation.',
 	rate_limited: 'O*NET is busy right now. Wait a moment and retry.',
 	auth: 'O*NET access is misconfigured (API key).',
@@ -32,6 +42,8 @@ const MESSAGES: Record<OnetErrorCode, string> = {
 
 const STATUSES: Record<OnetErrorCode, number> = {
 	invalid_code: 400,
+	invalid_request: 400,
+	invalid_query: 400,
 	not_found: 404,
 	rate_limited: 429,
 	auth: 502,

--- a/web/src/lib/server/tailor.test.ts
+++ b/web/src/lib/server/tailor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateEdits, MAX_EDITS, buildTailorInput, TAILOR_SCHEMA } from './tailor';
+import { validateEdits, MAX_EDITS, buildTailorInput, isValidTailorResume, TAILOR_SCHEMA } from './tailor';
 import { defaultResumeData } from '$lib/types';
 import type { ResumeData } from '$lib/types';
 import type { OnetOccupation } from '$lib/onet-types';
@@ -132,5 +132,34 @@ describe('buildTailorInput', () => {
 		const { prompt } = buildTailorInput(r, occupation);
 		expect(prompt).not.toContain('secret@example.com');
 		expect(prompt).not.toContain('555-0100');
+	});
+});
+
+describe('isValidTailorResume', () => {
+	it('accepts the complete application resume shape', () => {
+		expect(isValidTailorResume(structuredClone(defaultResumeData))).toBe(true);
+	});
+
+	it('rejects missing arrays before prompt construction', () => {
+		const resume = structuredClone(defaultResumeData) as unknown as Record<string, unknown>;
+		delete resume.education;
+		expect(isValidTailorResume(resume)).toBe(false);
+	});
+
+	it('rejects malformed and oversized bullet fields', () => {
+		const resume = structuredClone(defaultResumeData);
+		resume.workExperience = [
+			{
+				id: 'w1',
+				title: 'Engineer',
+				company: 'Acme',
+				location: '',
+				startDate: '',
+				endDate: '',
+				isPresent: false,
+				bullets: ['x'.repeat(12_001)],
+			},
+		];
+		expect(isValidTailorResume(resume)).toBe(false);
 	});
 });

--- a/web/src/lib/server/tailor.test.ts
+++ b/web/src/lib/server/tailor.test.ts
@@ -120,15 +120,46 @@ describe('buildTailorInput', () => {
 	it('offers profile, education, leadership, achievement, project stack, and font targets', () => {
 		const r = resume();
 		r.profile.summary = 'Software engineer.';
-		r.education = [{ id: 'e1', institution: 'University', location: '', degree: 'BS', major: '', startDate: '', endDate: '', isPresent: false, bullets: [] }];
-		r.leadership = [{ id: 'l1', title: 'Lead', organization: 'Club', location: '', startDate: '', endDate: '', isPresent: false, bullets: [] }];
+		r.education = [
+			{
+				id: 'e1',
+				institution: 'University',
+				location: '',
+				degree: 'BS',
+				major: '',
+				startDate: '',
+				endDate: '',
+				isPresent: false,
+				bullets: [],
+			},
+		];
+		r.leadership = [
+			{
+				id: 'l1',
+				title: 'Lead',
+				organization: 'Club',
+				location: '',
+				startDate: '',
+				endDate: '',
+				isPresent: false,
+				bullets: [],
+			},
+		];
 		r.projects[0] = { id: 'p1', name: 'Tool', stack: 'TypeScript', url: '', award: '', bullets: [] };
 		r.achievements = [{ id: 'a1', title: 'Award', date: '', description: 'Recognized for impact.' }];
 		const { allowed: a } = buildTailorInput(r, occupation);
 
 		expect([...a.bullets]).toEqual(['w1', 'p1', 'e1', 'l1']);
 		expect(a.fields).toEqual(
-			new Set(['profile', 'project-stack:p1', 'achievement-description:a1', 'baseSize', 'nameSize', 'headingSize', 'contactSize']),
+			new Set([
+				'profile',
+				'project-stack:p1',
+				'achievement-description:a1',
+				'baseSize',
+				'nameSize',
+				'headingSize',
+				'contactSize',
+			]),
 		);
 	});
 

--- a/web/src/lib/server/tailor.test.ts
+++ b/web/src/lib/server/tailor.test.ts
@@ -117,6 +117,21 @@ describe('buildTailorInput', () => {
 		expect([...a.skills]).toEqual(['s1']);
 	});
 
+	it('offers profile, education, leadership, achievement, project stack, and font targets', () => {
+		const r = resume();
+		r.profile.summary = 'Software engineer.';
+		r.education = [{ id: 'e1', institution: 'University', location: '', degree: 'BS', major: '', startDate: '', endDate: '', isPresent: false, bullets: [] }];
+		r.leadership = [{ id: 'l1', title: 'Lead', organization: 'Club', location: '', startDate: '', endDate: '', isPresent: false, bullets: [] }];
+		r.projects[0] = { id: 'p1', name: 'Tool', stack: 'TypeScript', url: '', award: '', bullets: [] };
+		r.achievements = [{ id: 'a1', title: 'Award', date: '', description: 'Recognized for impact.' }];
+		const { allowed: a } = buildTailorInput(r, occupation);
+
+		expect([...a.bullets]).toEqual(['w1', 'p1', 'e1', 'l1']);
+		expect(a.fields).toEqual(
+			new Set(['profile', 'project-stack:p1', 'achievement-description:a1', 'baseSize', 'nameSize', 'headingSize', 'contactSize']),
+		);
+	});
+
 	it('includes the resume evidence and the O*NET items in the prompt text', () => {
 		const { prompt } = buildTailorInput(resume(), occupation);
 		expect(prompt).toContain('Built an API.'); // existing bullet, so the model can ground its rewrite

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -131,16 +131,6 @@ export function buildTailorInput(
 ): { prompt: string; allowed: AllowedTargets } {
 	const bullets = [
 		...bulletTargets(resume),
-		...resume.education.map((e) => ({
-			id: e.id,
-			kind: 'education' as const,
-			label: `${e.degree} at ${e.institution}`,
-		})),
-		...resume.leadership.map((e) => ({
-			id: e.id,
-			kind: 'leadership' as const,
-			label: `${e.title} at ${e.organization}`,
-		})),
 	];
 	const skills = skillTargets(resume);
 	const fields = resume.profile.summary.trim() ? ['profile'] : [];

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -192,7 +192,7 @@ export function buildTailorInput(
 						resume.projects.find((project) => project.id === target.id) ??
 						resume.education.find((education) => education.id === target.id) ??
 						resume.leadership.find((leadership) => leadership.id === target.id);
-					return [target.id, entry?.bullets.length ?? 0];
+					return [target.id, entry?.bullets.filter(Boolean).length ?? 0];
 				}),
 			),
 		},

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -6,6 +6,65 @@ import { estimateOverOnePage } from '$lib/resume-utils';
 // A ceiling on how much one click can change, so a runaway response can't
 // rewrite the whole resume in a single pass.
 export const MAX_EDITS = 12;
+export const MAX_TAILOR_BODY_BYTES = 200_000;
+
+const MAX_ITEMS = 100;
+const MAX_FIELD_CHARS = 12_000;
+
+function record(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function boundedString(value: unknown): value is string {
+	return typeof value === 'string' && value.length <= MAX_FIELD_CHARS;
+}
+
+function objectFields(value: unknown, strings: string[], booleans: string[] = []): boolean {
+	return (
+		record(value) &&
+		strings.every((key) => boundedString(value[key])) &&
+		booleans.every((key) => typeof value[key] === 'boolean')
+	);
+}
+
+function numericFields(value: unknown, keys: string[]): boolean {
+	return record(value) && keys.every((key) => typeof value[key] === 'number' && Number.isFinite(value[key]));
+}
+
+function entries(value: unknown, strings: string[], booleans: string[] = [], bullets = false): boolean {
+	return (
+		Array.isArray(value) &&
+		value.length <= MAX_ITEMS &&
+		value.every(
+			(item) =>
+				objectFields(item, strings, booleans) &&
+				(!bullets ||
+					(Array.isArray((item as Record<string, unknown>).bullets) &&
+						((item as Record<string, unknown>).bullets as unknown[]).length <= MAX_ITEMS &&
+						((item as Record<string, unknown>).bullets as unknown[]).every(boundedString))),
+		)
+	);
+}
+
+export function isValidTailorResume(value: unknown): value is ResumeData {
+	if (!record(value)) return false;
+	return (
+		objectFields(value.personalInfo, ['name', 'phone', 'location', 'email', 'website', 'linkedin', 'github']) &&
+		objectFields(value.profile, ['summary']) &&
+		entries(value.clearance, ['id', 'level', 'status', 'dateGranted']) &&
+		entries(value.education, ['id', 'institution', 'location', 'degree', 'major', 'startDate', 'endDate'], ['isPresent'], true) &&
+		entries(value.projects, ['id', 'name', 'stack', 'url', 'award'], [], true) &&
+		entries(value.workExperience, ['id', 'title', 'company', 'location', 'startDate', 'endDate'], ['isPresent'], true) &&
+		entries(value.leadership, ['id', 'title', 'organization', 'location', 'startDate', 'endDate'], ['isPresent'], true) &&
+		entries(value.skills, ['id', 'category', 'skills']) &&
+		entries(value.achievements, ['id', 'title', 'date', 'description']) &&
+		objectFields(value.colors, ['headColor', 'textColor', 'accentColor', 'linkColor']) &&
+		numericFields(value.fonts, ['baseSize', 'nameSize', 'headingSize', 'contactSize']) &&
+		Array.isArray(value.sectionOrder) &&
+		value.sectionOrder.length <= MAX_ITEMS &&
+		value.sectionOrder.every(boundedString)
+	);
+}
 
 export interface AllowedTargets {
 	bullets: Set<string>;

--- a/web/src/lib/server/tailor.ts
+++ b/web/src/lib/server/tailor.ts
@@ -52,10 +52,25 @@ export function isValidTailorResume(value: unknown): value is ResumeData {
 		objectFields(value.personalInfo, ['name', 'phone', 'location', 'email', 'website', 'linkedin', 'github']) &&
 		objectFields(value.profile, ['summary']) &&
 		entries(value.clearance, ['id', 'level', 'status', 'dateGranted']) &&
-		entries(value.education, ['id', 'institution', 'location', 'degree', 'major', 'startDate', 'endDate'], ['isPresent'], true) &&
+		entries(
+			value.education,
+			['id', 'institution', 'location', 'degree', 'major', 'startDate', 'endDate'],
+			['isPresent'],
+			true,
+		) &&
 		entries(value.projects, ['id', 'name', 'stack', 'url', 'award'], [], true) &&
-		entries(value.workExperience, ['id', 'title', 'company', 'location', 'startDate', 'endDate'], ['isPresent'], true) &&
-		entries(value.leadership, ['id', 'title', 'organization', 'location', 'startDate', 'endDate'], ['isPresent'], true) &&
+		entries(
+			value.workExperience,
+			['id', 'title', 'company', 'location', 'startDate', 'endDate'],
+			['isPresent'],
+			true,
+		) &&
+		entries(
+			value.leadership,
+			['id', 'title', 'organization', 'location', 'startDate', 'endDate'],
+			['isPresent'],
+			true,
+		) &&
 		entries(value.skills, ['id', 'category', 'skills']) &&
 		entries(value.achievements, ['id', 'title', 'date', 'description']) &&
 		objectFields(value.colors, ['headColor', 'textColor', 'accentColor', 'linkColor']) &&
@@ -129,9 +144,7 @@ export function buildTailorInput(
 	resume: ResumeData,
 	occupation: OnetOccupation,
 ): { prompt: string; allowed: AllowedTargets } {
-	const bullets = [
-		...bulletTargets(resume),
-	];
+	const bullets = [...bulletTargets(resume)];
 	const skills = skillTargets(resume);
 	const fields = resume.profile.summary.trim() ? ['profile'] : [];
 	const fontBounds = 'baseSize=6-14, nameSize=14-32, headingSize=10-24, contactSize=7-16';

--- a/web/src/lib/server/template-conversion.test.ts
+++ b/web/src/lib/server/template-conversion.test.ts
@@ -4,6 +4,7 @@ import {
 	extractDocxTemplateContext,
 	generateTypstTemplateFromDesign,
 	MAX_OOXML_CONTEXT_CHARS,
+	MAX_OOXML_PART_BYTES,
 	TEMPLATE_CONTENT_MARKER,
 	type TemplateDesign,
 } from './template-conversion';
@@ -55,6 +56,13 @@ describe('DOCX template context extraction', () => {
 		zip.file('word/document.xml', 'x'.repeat(MAX_OOXML_CONTEXT_CHARS + 100));
 		const context = await extractDocxTemplateContext(await zip.generateAsync({ type: 'nodebuffer' }));
 		expect(context.length).toBeLessThan(MAX_OOXML_CONTEXT_CHARS + 100);
+	});
+
+	it('rejects a highly compressed OOXML part before inflating it', async () => {
+		const zip = new JSZip();
+		zip.file('word/document.xml', 'x'.repeat(MAX_OOXML_PART_BYTES + 1));
+		const buffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+		await expect(extractDocxTemplateContext(buffer)).rejects.toThrow('too large when uncompressed');
 	});
 });
 

--- a/web/src/lib/server/template-conversion.test.ts
+++ b/web/src/lib/server/template-conversion.test.ts
@@ -28,6 +28,16 @@ const DESIGN: TemplateDesign = {
 	showHeaderRule: true,
 };
 
+function underreportUncompressedSize(buffer: Buffer): Buffer {
+	const patched = Buffer.from(buffer);
+	for (let offset = 0; offset <= patched.length - 28; offset++) {
+		const signature = patched.readUInt32LE(offset);
+		if (signature === 0x04034b50) patched.writeUInt32LE(1, offset + 22);
+		if (signature === 0x02014b50) patched.writeUInt32LE(1, offset + 24);
+	}
+	return patched;
+}
+
 describe('DOCX template context extraction', () => {
 	it('includes document, style, and header XML while excluding unrelated files', async () => {
 		const zip = new JSZip();
@@ -63,6 +73,16 @@ describe('DOCX template context extraction', () => {
 		zip.file('word/document.xml', 'x'.repeat(MAX_OOXML_PART_BYTES + 1));
 		const buffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
 		await expect(extractDocxTemplateContext(buffer)).rejects.toThrow('too large when uncompressed');
+	});
+
+	it('stops inflating when ZIP metadata under-reports the output size', async () => {
+		const zip = new JSZip();
+		zip.file('word/document.xml', 'x'.repeat(MAX_OOXML_PART_BYTES + 1));
+		const buffer = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+
+		await expect(extractDocxTemplateContext(underreportUncompressedSize(buffer))).rejects.toThrow(
+			'too large when uncompressed',
+		);
 	});
 });
 

--- a/web/src/lib/server/template-conversion.ts
+++ b/web/src/lib/server/template-conversion.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip';
+import type { Readable } from 'node:stream';
 export { DOCX_TEMPLATE_MAX_BYTES } from '$lib/template-limits';
 
 export const TEMPLATE_CONVERSION_MODEL = 'gpt-5.6-luna';
@@ -107,6 +108,33 @@ function isUsefulPart(path: string): boolean {
 	);
 }
 
+async function readBoundedPart(entry: JSZip.JSZipObject, path: string): Promise<string> {
+	const stream = entry.nodeStream('nodebuffer') as Readable;
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		let size = 0;
+		let settled = false;
+		stream.on('data', (chunk: Buffer | Uint8Array) => {
+			if (settled) return;
+			const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+			size += bytes.byteLength;
+			if (size > MAX_OOXML_PART_BYTES) {
+				settled = true;
+				stream.destroy();
+				reject(new Error(`DOCX part ${path} is too large when uncompressed.`));
+				return;
+			}
+			chunks.push(bytes);
+		});
+		stream.on('end', () => {
+			if (!settled) resolve(Buffer.concat(chunks, size).toString('utf8'));
+		});
+		stream.on('error', (error) => {
+			if (!settled) reject(error);
+		});
+	});
+}
+
 /** Extracts a bounded set of layout-relevant OOXML parts from a DOCX archive. */
 export async function extractDocxTemplateContext(buffer: Buffer): Promise<string> {
 	const zip = await JSZip.loadAsync(buffer);
@@ -124,7 +152,7 @@ export async function extractDocxTemplateContext(buffer: Buffer): Promise<string
 		if (typeof uncompressedSize === 'number' && uncompressedSize > MAX_OOXML_PART_BYTES) {
 			throw new Error(`DOCX part ${path} is too large when uncompressed.`);
 		}
-		const xml = await entry.async('string');
+		const xml = await readBoundedPart(entry, path);
 		const included = xml.slice(0, remaining);
 		parts.push(`--- ${path} ---\n${included}`);
 		remaining -= included.length;

--- a/web/src/lib/server/template-conversion.ts
+++ b/web/src/lib/server/template-conversion.ts
@@ -237,8 +237,10 @@ export function generateTypstTemplateFromDesign(input: TemplateDesign): string {
 }
 
 #let period-worked(start-date, end-date) = {
-  let finish = if type(end-date) == str { end-date } else if end-date.year() == datetime.today().year() and end-date.month() == datetime.today().month() { "Present" } else { end-date.display("[month repr:short] [year]") }
-  [#start-date.display("[month repr:short] [year]") - #finish]
+  let display-date(value) = if type(value) == str { value } else { value.display("[month repr:short] [year]") }
+  let start = display-date(start-date)
+  let finish = display-date(end-date)
+  if start == "" { finish } else if finish == "" { start } else { [#start - #finish] }
 }
 
 #let work-heading(title, company, location, start-date, end-date, body) = {

--- a/web/src/lib/server/template-conversion.ts
+++ b/web/src/lib/server/template-conversion.ts
@@ -1,9 +1,10 @@
 import JSZip from 'jszip';
+export { DOCX_TEMPLATE_MAX_BYTES } from '$lib/template-limits';
 
 export const TEMPLATE_CONVERSION_MODEL = 'gpt-5.6-luna';
-export const DOCX_TEMPLATE_MAX_BYTES = 5 * 1024 * 1024;
 export const TEMPLATE_CONTENT_MARKER = '// ========== RESUME CONTENT ==========';
 export const MAX_OOXML_CONTEXT_CHARS = 180_000;
+export const MAX_OOXML_PART_BYTES = 1024 * 1024;
 
 const PRIMARY_PARTS = [
 	'word/styles.xml',
@@ -119,6 +120,10 @@ export async function extractDocxTemplateContext(buffer: Buffer): Promise<string
 		if (remaining <= 0) break;
 		const entry = zip.file(path);
 		if (!entry) continue;
+		const uncompressedSize = (entry as unknown as { _data?: { uncompressedSize?: number } })._data?.uncompressedSize;
+		if (typeof uncompressedSize === 'number' && uncompressedSize > MAX_OOXML_PART_BYTES) {
+			throw new Error(`DOCX part ${path} is too large when uncompressed.`);
+		}
 		const xml = await entry.async('string');
 		const included = xml.slice(0, remaining);
 		parts.push(`--- ${path} ---\n${included}`);

--- a/web/src/lib/store.test.ts
+++ b/web/src/lib/store.test.ts
@@ -17,7 +17,9 @@ describe('mergeWithDefaults', () => {
 
 	it('deep-merges nested settings and appends newly introduced sections', () => {
 		const merged = mergeWithDefaults({
-			personalInfo: { name: 'Ada' } as Partial<typeof defaultResumeData.personalInfo> as typeof defaultResumeData.personalInfo,
+			personalInfo: { name: 'Ada' } as Partial<
+				typeof defaultResumeData.personalInfo
+			> as typeof defaultResumeData.personalInfo,
 			fonts: { baseSize: 10 } as typeof defaultResumeData.fonts,
 			sectionOrder: ['experience', 'profile'],
 		});

--- a/web/src/lib/store.test.ts
+++ b/web/src/lib/store.test.ts
@@ -14,4 +14,29 @@ describe('mergeWithDefaults', () => {
 		const merged = mergeWithDefaults(saved);
 		expect(merged.personalInfo.name).toBe('Ada');
 	});
+
+	it('deep-merges nested settings and appends newly introduced sections', () => {
+		const merged = mergeWithDefaults({
+			personalInfo: { name: 'Ada' } as Partial<typeof defaultResumeData.personalInfo> as typeof defaultResumeData.personalInfo,
+			fonts: { baseSize: 10 } as typeof defaultResumeData.fonts,
+			sectionOrder: ['experience', 'profile'],
+		});
+
+		expect(merged.personalInfo.name).toBe('Ada');
+		expect(merged.personalInfo.github).toBe('');
+		expect(merged.fonts.baseSize).toBe(10);
+		expect(merged.fonts.nameSize).toBe(defaultResumeData.fonts.nameSize);
+		expect(merged.sectionOrder.slice(0, 2)).toEqual(['experience', 'profile']);
+		expect(merged.sectionOrder).toContain('clearance');
+	});
+
+	it('returns fresh nested defaults rather than shared mutable objects', () => {
+		const first = mergeWithDefaults({});
+		first.personalInfo.name = 'Changed';
+		first.sectionOrder.pop();
+		const second = mergeWithDefaults({});
+
+		expect(second.personalInfo.name).toBe('');
+		expect(second.sectionOrder).toEqual(defaultResumeData.sectionOrder);
+	});
 });

--- a/web/src/lib/store.ts
+++ b/web/src/lib/store.ts
@@ -8,7 +8,8 @@ export function mergeWithDefaults(saved: Partial<ResumeData>): ResumeData {
 	const defaults = structuredClone(defaultResumeData);
 	const savedOrder = Array.isArray(saved.sectionOrder)
 		? saved.sectionOrder.filter(
-				(id, index): id is SectionId => defaultSectionOrder.includes(id as SectionId) && saved.sectionOrder?.indexOf(id) === index,
+				(id, index): id is SectionId =>
+					defaultSectionOrder.includes(id as SectionId) && saved.sectionOrder?.indexOf(id) === index,
 			)
 		: [];
 	const sectionOrder = [...savedOrder, ...defaultSectionOrder.filter((id) => !savedOrder.includes(id))];
@@ -45,9 +46,9 @@ export function createResumeStore() {
 			if (typeof window !== 'undefined') {
 				try {
 					const saved = window.localStorage.getItem('resumeData');
-				if (saved) {
-					set(mergeWithDefaults(JSON.parse(saved)));
-				}
+					if (saved) {
+						set(mergeWithDefaults(JSON.parse(saved)));
+					}
 				} catch (e) {
 					console.error('Failed to load saved resume data:', e);
 				}

--- a/web/src/lib/store.ts
+++ b/web/src/lib/store.ts
@@ -1,36 +1,63 @@
 import { writable } from 'svelte/store';
-import type { ResumeData } from './types';
-import { defaultResumeData } from './types';
+import type { ResumeData, SectionId } from './types';
+import { defaultResumeData, defaultSectionOrder } from './types';
 
 // Old saved data can predate fields added to ResumeData since it was written
 // (e.g. clearance); fill those in from defaults instead of leaving them undefined.
 export function mergeWithDefaults(saved: Partial<ResumeData>): ResumeData {
-	return { ...defaultResumeData, ...saved };
+	const defaults = structuredClone(defaultResumeData);
+	const savedOrder = Array.isArray(saved.sectionOrder)
+		? saved.sectionOrder.filter(
+				(id, index): id is SectionId => defaultSectionOrder.includes(id as SectionId) && saved.sectionOrder?.indexOf(id) === index,
+			)
+		: [];
+	const sectionOrder = [...savedOrder, ...defaultSectionOrder.filter((id) => !savedOrder.includes(id))];
+	const arrays = <K extends keyof ResumeData>(key: K): ResumeData[K] =>
+		(Array.isArray(saved[key]) ? saved[key] : defaults[key]) as ResumeData[K];
+
+	return {
+		...defaults,
+		...saved,
+		personalInfo: { ...defaults.personalInfo, ...saved.personalInfo },
+		profile: { ...defaults.profile, ...saved.profile },
+		colors: { ...defaults.colors, ...saved.colors },
+		fonts: { ...defaults.fonts, ...saved.fonts },
+		clearance: arrays('clearance'),
+		education: arrays('education'),
+		projects: arrays('projects'),
+		workExperience: arrays('workExperience'),
+		leadership: arrays('leadership'),
+		skills: arrays('skills'),
+		achievements: arrays('achievements'),
+		sectionOrder,
+	};
 }
 
-function createResumeStore() {
-	const { subscribe, set, update } = writable<ResumeData>(defaultResumeData);
+export function createResumeStore() {
+	const { subscribe, set, update } = writable<ResumeData>(structuredClone(defaultResumeData));
 
 	return {
 		subscribe,
 		set,
 		update,
-		reset: () => set(defaultResumeData),
+		reset: () => set(structuredClone(defaultResumeData)),
 		loadFromStorage: () => {
 			if (typeof window !== 'undefined') {
-				const saved = localStorage.getItem('resumeData');
+				try {
+					const saved = window.localStorage.getItem('resumeData');
 				if (saved) {
-					try {
-						set(mergeWithDefaults(JSON.parse(saved)));
-					} catch (e) {
-						console.error('Failed to load saved resume data:', e);
-					}
+					set(mergeWithDefaults(JSON.parse(saved)));
+				}
+				} catch (e) {
+					console.error('Failed to load saved resume data:', e);
 				}
 			}
 		},
 		saveToStorage: (data: ResumeData) => {
-			if (typeof window !== 'undefined') {
-				localStorage.setItem('resumeData', JSON.stringify(data));
+			try {
+				if (typeof window !== 'undefined') window.localStorage.setItem('resumeData', JSON.stringify(data));
+			} catch (e) {
+				console.error('Failed to save resume data:', e);
 			}
 		},
 	};

--- a/web/src/lib/template-limits.ts
+++ b/web/src/lib/template-limits.ts
@@ -1,0 +1,3 @@
+// Leaves headroom below Vercel's 4.5 MB request-body limit for multipart framing.
+export const DOCX_TEMPLATE_MAX_BYTES = 4 * 1024 * 1024;
+export const DOCX_TEMPLATE_MAX_LABEL = '4 MB';

--- a/web/src/lib/typst-generator.test.ts
+++ b/web/src/lib/typst-generator.test.ts
@@ -119,7 +119,8 @@ describe('generateTypstCode sanitization', () => {
 		const payload = '2020, month: 1, day: 1) ; let pwned = eval("1+1") ; datetime(year: 2021-01';
 		const content = contentOf(withOverrides({ workExperience: [oneJob({ startDate: payload })] }));
 		expect(content).not.toContain('pwned');
-		expect(content).toContain('""');
+		expect(content).toContain('  "",\n  "Present"');
+		expect(content).not.toContain('datetime.today()');
 	});
 
 	it('rejects an out-of-range month', () => {

--- a/web/src/lib/typst-generator.test.ts
+++ b/web/src/lib/typst-generator.test.ts
@@ -119,13 +119,31 @@ describe('generateTypstCode sanitization', () => {
 		const payload = '2020, month: 1, day: 1) ; let pwned = eval("1+1") ; datetime(year: 2021-01';
 		const content = contentOf(withOverrides({ workExperience: [oneJob({ startDate: payload })] }));
 		expect(content).not.toContain('pwned');
-		expect(content).toContain('datetime.today()');
+		expect(content).toContain('""');
 	});
 
 	it('rejects an out-of-range month', () => {
 		const content = contentOf(withOverrides({ workExperience: [oneJob({ startDate: '2020-13' })] }));
 		expect(content).not.toContain('month: 13');
-		expect(content).toContain('datetime.today()');
+		expect(content).not.toContain('datetime.today()');
+	});
+
+	it('renders a year-only date as the stated year', () => {
+		const content = contentOf(
+			withOverrides({ workExperience: [oneJob({ startDate: '2019', endDate: '2021', isPresent: false })] }),
+		);
+		expect(content).toContain('"2019"');
+		expect(content).toContain('"2021"');
+		expect(content).not.toContain('datetime.today()');
+	});
+
+	it('renders blank inactive dates as blank values', () => {
+		const content = contentOf(
+			withOverrides({ workExperience: [oneJob({ startDate: '', endDate: '', isPresent: false })] }),
+		);
+		expect(content).toContain('  "",\n  ""');
+		expect(content).not.toContain('datetime.today()');
+		expect(content).not.toContain('"Present"');
 	});
 
 	it('still renders a valid date', () => {

--- a/web/src/lib/typst-generator.ts
+++ b/web/src/lib/typst-generator.ts
@@ -17,6 +17,7 @@ export const RESUME_CONTENT_MARKER = '// ========== RESUME CONTENT ==========';
 // Dates land in Typst code position, so anything that is not a plain YYYY-MM is rejected outright
 // rather than escaped.
 const YEAR_MONTH = /^(\d{4})-(\d{1,2})$/;
+const YEAR = /^\d{4}$/;
 
 function parseYearMonth(dateStr: string): { year: number; month: number } | null {
 	const match = YEAR_MONTH.exec(dateStr.trim());
@@ -27,8 +28,9 @@ function parseYearMonth(dateStr: string): { year: number; month: number } | null
 }
 
 function formatDate(dateStr: string): string {
+	const trimmed = dateStr.trim();
 	const parsed = parseYearMonth(dateStr);
-	if (!parsed) return 'datetime.today()';
+	if (!parsed) return YEAR.test(trimmed) ? `"${trimmed}"` : '""';
 	return `datetime(year: ${parsed.year}, month: ${parsed.month}, day: 1)`;
 }
 
@@ -377,22 +379,11 @@ export function generateTypstCode(data: ResumeData, customTemplate?: string | nu
 }
 
 #let period_worked(start-date, end-date) = {
-  if type(end-date) == str and end-date == "Present" {
-    end-date = datetime.today()
-  }
-
-  return [
-    #start-date.display("[month repr:short] [year]") -
-    #if (
-      (end-date.month() == datetime.today().month()) and
-        (end-date.year() == datetime.today().year())
-      ) [
-        Present
-      ] else [
-        #end-date.display("[month repr:short] [year]")
-      ]
-    ]
-  }
+  let display-date(value) = if type(value) == str { value } else { value.display("[month repr:short] [year]") }
+  let start = display-date(start-date)
+  let finish = display-date(end-date)
+  if start == "" { finish } else if finish == "" { start } else { [#start - #finish] }
+}
 
 #let work-heading(title, company, location, start-date, end-date, body) = {
   generic_2x2(

--- a/web/src/routes/api/extract/+server.ts
+++ b/web/src/routes/api/extract/+server.ts
@@ -15,6 +15,7 @@ import { validateExtractedDocument, type DocumentMetrics } from '$lib/document-q
 
 // This endpoint is dynamic (the root layout sets prerender=true for pages).
 export const prerender = false;
+export const config = { maxDuration: 60 };
 
 function fail(e: ExtractError): Response {
 	return json({ error: { code: e.code, message: e.message } }, { status: e.status });

--- a/web/src/routes/api/extract/+server.ts
+++ b/web/src/routes/api/extract/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { OPENAI_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import OpenAI from 'openai';
 import {
 	MODEL,
@@ -43,8 +43,9 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	const gateError = validateExtractedDocument(filename, text);
 	if (gateError) return preflightFailure(gateError);
+	if (!env.OPENAI_API_KEY) return fail(extractError('auth'));
 
-	const client = new OpenAI({ apiKey: OPENAI_API_KEY });
+	const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
 	const method = ['text', 'ocr', 'hybrid'].includes(metrics?.method ?? '') ? metrics?.method : 'text';
 	const content: OpenAI.Responses.ResponseInputContent[] = [
 		{

--- a/web/src/routes/api/extract/+server.ts
+++ b/web/src/routes/api/extract/+server.ts
@@ -8,9 +8,9 @@ import {
 	EXTRACTION_PROMPT,
 	mapOpenAIError,
 	extractError,
+	validateExtractedResume,
 	type ExtractError,
 } from '$lib/server/extraction';
-import type { ExtractedResume } from '$lib/types';
 import { validateExtractedDocument, type DocumentMetrics } from '$lib/document-quality';
 
 // This endpoint is dynamic (the root layout sets prerender=true for pages).
@@ -72,23 +72,12 @@ export const POST: RequestHandler = async ({ request }) => {
 		const raw = response.output_text;
 		if (!raw) return fail(extractError('parse_failed'));
 
-		const data = JSON.parse(raw) as ExtractedResume;
+		const data = validateExtractedResume(JSON.parse(raw));
+		if (!data) return fail(extractError('parse_failed'));
 		return json({ data });
 	} catch (err) {
-		console.error(
-			'OPENAI_DEBUG',
-			JSON.stringify(
-				{
-					name: (err as any)?.name,
-					status: (err as any)?.status,
-					code: (err as any)?.code,
-					message: (err as any)?.message,
-					error: (err as any)?.error,
-				},
-				null,
-				2,
-			),
-		);
+		const detail = err as { status?: unknown; code?: unknown };
+		console.error('OpenAI extraction failed', { status: detail?.status, code: detail?.code });
 		// SyntaxError from JSON.parse -> parse_failed; otherwise map the OpenAI/network error.
 		if (err instanceof SyntaxError) return fail(extractError('parse_failed'));
 		return fail(mapOpenAIError(err));

--- a/web/src/routes/api/onet/search/+server.ts
+++ b/web/src/routes/api/onet/search/+server.ts
@@ -10,7 +10,7 @@ const MAX_KEYWORD = 100;
 export const GET: RequestHandler = async ({ url }) => {
 	const keyword = (url.searchParams.get('keyword') ?? '').trim();
 	if (!keyword) return onetOk({ occupations: [] });
-	if (keyword.length > MAX_KEYWORD) return onetFail(onetError('invalid_code'));
+	if (keyword.length > MAX_KEYWORD) return onetFail(onetError('invalid_query'));
 
 	const key = onetKey();
 	if (!key) return onetFail(onetError('auth'));

--- a/web/src/routes/api/onet/tailor/+server.ts
+++ b/web/src/routes/api/onet/tailor/+server.ts
@@ -15,6 +15,7 @@ import {
 import type { ExtractError } from '$lib/server/extraction';
 
 export const prerender = false;
+export const config = { maxDuration: 60 };
 
 // Same { error: { code, message } } envelope the other endpoints use.
 function fail(e: ExtractError): Response {

--- a/web/src/routes/api/onet/tailor/+server.ts
+++ b/web/src/routes/api/onet/tailor/+server.ts
@@ -5,8 +5,13 @@ import OpenAI from 'openai';
 import { MODEL, mapOpenAIError, extractError } from '$lib/server/extraction';
 import { fetchOccupation, isValidOnetCode, onetError } from '$lib/server/onet';
 import { onetFail, onetKey } from '$lib/server/onet-route';
-import { buildTailorInput, validateEdits, TAILOR_SCHEMA } from '$lib/server/tailor';
-import type { ResumeData } from '$lib/types';
+import {
+	buildTailorInput,
+	isValidTailorResume,
+	MAX_TAILOR_BODY_BYTES,
+	validateEdits,
+	TAILOR_SCHEMA,
+} from '$lib/server/tailor';
 import type { ExtractError } from '$lib/server/extraction';
 
 export const prerender = false;
@@ -19,16 +24,23 @@ function fail(e: ExtractError): Response {
 // Personalised to the caller's resume, so unlike the other O*NET routes this
 // one must not be cached at the edge.
 export const POST: RequestHandler = async ({ request }) => {
-	let body: { resume?: ResumeData; code?: string };
+	const declaredLength = Number(request.headers.get('content-length') ?? 0);
+	if (declaredLength > MAX_TAILOR_BODY_BYTES) return onetFail(onetError('invalid_request', 413));
+
+	let body: { resume?: unknown; code?: unknown };
 	try {
-		body = await request.json();
+		const raw = await request.text();
+		if (new TextEncoder().encode(raw).byteLength > MAX_TAILOR_BODY_BYTES) {
+			return onetFail(onetError('invalid_request', 413));
+		}
+		body = JSON.parse(raw) as { resume?: unknown; code?: unknown };
 	} catch {
-		return onetFail(onetError('invalid_code'));
+		return onetFail(onetError('invalid_request'));
 	}
 
-	const code = body.code ?? '';
+	const code = typeof body.code === 'string' ? body.code : '';
 	if (!isValidOnetCode(code)) return onetFail(onetError('invalid_code'));
-	if (!body.resume || typeof body.resume !== 'object') return onetFail(onetError('invalid_code'));
+	if (!isValidTailorResume(body.resume)) return onetFail(onetError('invalid_request'));
 
 	const key = onetKey();
 	if (!key) return onetFail(onetError('auth'));

--- a/web/src/routes/api/onet/tailor/+server.ts
+++ b/web/src/routes/api/onet/tailor/+server.ts
@@ -52,6 +52,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
 		const response = await client.responses.create({
 			model: MODEL,
+			store: false,
 			input: [{ role: 'user', content: [{ type: 'input_text', text: prompt }] }],
 			reasoning: { effort: 'medium' },
 			text: {

--- a/web/src/routes/api/onet/tailor/+server.ts
+++ b/web/src/routes/api/onet/tailor/+server.ts
@@ -56,7 +56,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	}
 
 	const { prompt, allowed } = buildTailorInput(body.resume, occupation);
-	if (allowed.bullets.size === 0 && allowed.skills.size === 0) {
+	if (allowed.bullets.size === 0 && allowed.skills.size === 0 && (allowed.fields?.size ?? 0) === 0) {
 		return json({ edits: [], reason: 'no_targets' });
 	}
 

--- a/web/src/routes/api/onet/tailor/+server.ts
+++ b/web/src/routes/api/onet/tailor/+server.ts
@@ -13,6 +13,7 @@ import {
 	TAILOR_SCHEMA,
 } from '$lib/server/tailor';
 import type { ExtractError } from '$lib/server/extraction';
+import { readBoundedBody, RequestBodyTooLargeError } from '$lib/server/bounded-body';
 
 export const prerender = false;
 export const config = { maxDuration: 60 };
@@ -28,14 +29,15 @@ export const POST: RequestHandler = async ({ request }) => {
 	const declaredLength = Number(request.headers.get('content-length') ?? 0);
 	if (declaredLength > MAX_TAILOR_BODY_BYTES) return onetFail(onetError('invalid_request', 413));
 
-	let body: { resume?: unknown; code?: unknown };
+	let body: Record<string, unknown>;
 	try {
-		const raw = await request.text();
-		if (new TextEncoder().encode(raw).byteLength > MAX_TAILOR_BODY_BYTES) {
-			return onetFail(onetError('invalid_request', 413));
+		const parsed: unknown = JSON.parse(await readBoundedBody(request, MAX_TAILOR_BODY_BYTES));
+		if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+			return onetFail(onetError('invalid_request'));
 		}
-		body = JSON.parse(raw) as { resume?: unknown; code?: unknown };
-	} catch {
+		body = parsed as Record<string, unknown>;
+	} catch (error) {
+		if (error instanceof RequestBodyTooLargeError) return onetFail(onetError('invalid_request', 413));
 		return onetFail(onetError('invalid_request'));
 	}
 

--- a/web/src/routes/api/template/convert/+server.ts
+++ b/web/src/routes/api/template/convert/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { OPENAI_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import OpenAI from 'openai';
 import { mapOpenAIError } from '$lib/server/extraction';
 import { DOCX_TEMPLATE_MAX_LABEL } from '$lib/template-limits';
@@ -49,7 +49,8 @@ export const POST: RequestHandler = async ({ request }) => {
 	}
 
 	try {
-		const client = new OpenAI({ apiKey: OPENAI_API_KEY });
+		if (!env.OPENAI_API_KEY) return error('auth', 'AI service is misconfigured (API key).', 502);
+		const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
 		const response = await client.responses.create({
 			model: TEMPLATE_CONVERSION_MODEL,
 			instructions: TEMPLATE_CONVERSION_PROMPT,

--- a/web/src/routes/api/template/convert/+server.ts
+++ b/web/src/routes/api/template/convert/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { OPENAI_API_KEY } from '$env/static/private';
 import OpenAI from 'openai';
 import { mapOpenAIError } from '$lib/server/extraction';
+import { DOCX_TEMPLATE_MAX_LABEL } from '$lib/template-limits';
 import {
 	DOCX_TEMPLATE_MAX_BYTES,
 	extractDocxTemplateContext,
@@ -35,7 +36,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		return error('invalid_file', 'Choose a Word template ending in .docx.', 400);
 	}
 	if (file.size > DOCX_TEMPLATE_MAX_BYTES) {
-		return error('file_too_large', 'The DOCX template must be 5 MB or smaller.', 413);
+		return error('file_too_large', `The DOCX template must be ${DOCX_TEMPLATE_MAX_LABEL} or smaller.`, 413);
 	}
 
 	let buffer: Buffer;


### PR DESCRIPTION
## Summary

Fixes every currently open issue labeled `bug`, with one focused implementation commit per issue (and separate formatting/CI commits for #23). Also adds the requested harness field to AI-authored issue and PR attribution.

## Issue fixes

- Closes #14 ? sets `store: false` on O*NET tailoring Responses API calls so resume content is not retained.
- Closes #15 ? maps model-visible filtered bullet indices back to the original snapshot, applies removals last in descending order, and adjusts highlight paths after removals.
- Closes #16 ? caps tailor request bodies, validates the complete resume shape before prompt construction, and returns accurate request/search validation errors.
- Closes #17 ? lowers DOCX template uploads to 4 MB for multipart headroom and rejects oversized uncompressed OOXML parts before inflation.
- Closes #18 ? preserves year-only dates, renders blank dates as blank, and updates built-in/generated/example template date helpers.
- Closes #19 ? deep-merges nested stored data, appends new sections during migration, clones defaults, and catches blocked/quota storage failures.
- Closes #20 ? enables all supported tailoring targets, including education and leadership bullets, profile and other fields, and fonts.
- Closes #21 ? gives the tailor drawer dialog semantics, initial focus, a focus trap, scoped Escape handling, and opener-focus restoration.
- Closes #22 ? updates `@xmldom/xmldom` from 0.8.13 to patched 0.8.15; the production audit is clean.
- Closes #23 ? formats the application and adds lint plus production build checks to CI.
- Closes #24 ? excludes merge commits from Conventional Commit validation so GitHub's Update branch merges do not fail CI.
- Closes #25 ? removes contradictory inference instructions, forbids guessed contact data, validates parsed model output, and limits error logging to status/code.
- Closes #26 ? sets a consistent 60-second maximum duration on all AI-backed routes.
- Closes #27 ? centralizes browser downloads through an attached anchor and delays object URL revocation to avoid asynchronous download races.
- Closes #28 ? removes the hard-coded US Letter dimensions from the preview label because active templates may use A4 or Letter.

## Additional policy update

- Requires AI-authored issues and PRs to identify provider, model, and harness in `AGENTS.md`, `CONTRIBUTING.md`, and GitHub templates.

## Verification

- `npm test` ? 18 files, 211 tests passed.
- `npm run check` ? 0 errors and 0 warnings.
- `npm run lint` ? passed.
- `npm audit --omit=dev` ? 0 vulnerabilities.
- `node .github/scripts/check-commit-messages.mjs origin/main HEAD` ? all 20 commits passed.
- `npm run build` ? Vite client and server bundles compiled; the final Vercel adapter packaging step cannot create symlinks in this Windows OneDrive checkout (`EPERM`). The new Ubuntu CI build step verifies deploy packaging in the supported CI environment.

## Risk and deployment

The route limits are compatible with Vercel Hobby. Tailor payload validation may reject malformed direct API clients that previously reached an unhandled 500. DOCX templates above 4 MB are now rejected intentionally. No database, persistent server storage, or new runtime dependency was added.

AI assistance: yes

Agent provider: OpenAI
Agent model: gpt-5.6-sol
Agent harness: Codex



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI-assisted issue and pull request submissions now include provider, model, and harness attribution guidance.
  - Tailoring supports education and leadership bullets, with improved keyboard focus handling in the tailoring drawer.
  - Resume and DOCX processing now provide stronger validation and safer downloads.

- **Improvements**
  - DOCX template uploads are limited to 4 MB.
  - Date ranges render more accurately without inferring missing or invalid dates.
  - O*NET requests provide clearer validation errors.

- **Quality**
  - Automated checks now include formatting and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->