### PR TITLE
feat: rename application to ResumeSmith

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible problem with Resume Smith
+description: Report a reproducible problem with ResumeSmith
 title: "[Bug]: "
 labels:
   - bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible problem with Resume Generator
+description: Report a reproducible problem with Resume Smith
 title: "[Bug]: "
 labels:
   - bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an improvement to Resume Smith
+description: Suggest an improvement to ResumeSmith
 title: "[Feature]: "
 labels:
   - enhancement

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an improvement to Resume Generator
+description: Suggest an improvement to Resume Smith
 title: "[Feature]: "
 labels:
   - enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve Resume Generator. Contributions involving document uploads, AI processing, or generated PDFs
+Thanks for helping improve Resume Smith. Contributions involving document uploads, AI processing, or generated PDFs
 deserve particular care because they affect user privacy, API cost, and document correctness.
 
 By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve Resume Smith. Contributions involving document uploads, AI processing, or generated PDFs
+Thanks for helping improve ResumeSmith. Contributions involving document uploads, AI processing, or generated PDFs
 deserve particular care because they affect user privacy, API cost, and document correctness.
 
 By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Resume Smith
+# ResumeSmith
 
-Resume Smith is a privacy-conscious resume builder for forging polished, job-ready resumes with live Typst rendering, PDF export, AI-assisted parsing, O\*NET occupation data, and session-scoped custom templates.
+ResumeSmith is a privacy-conscious resume builder for forging polished, job-ready resumes with live Typst rendering, PDF export, AI-assisted parsing, O\*NET occupation data, and session-scoped custom templates.
 
 [Try the deployed app](https://rg.barknote.top)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Resume Generator
+# Resume Smith
 
-A privacy-conscious resume builder with live Typst rendering, PDF export, AI-assisted resume parsing, O\*NET occupation data, and session-scoped custom templates.
+Resume Smith is a privacy-conscious resume builder for forging polished, job-ready resumes with live Typst rendering, PDF export, AI-assisted parsing, O\*NET occupation data, and session-scoped custom templates.
 
 [Try the deployed app](https://rg.barknote.top)
 

--- a/docs/examples/modern-teal.typ
+++ b/docs/examples/modern-teal.typ
@@ -1,4 +1,4 @@
-// Example custom template for Resume Smith.
+// Example custom template for ResumeSmith.
 // Upload this file with the "Upload Template" button.
 
 #let ink = rgb("183153")
@@ -148,4 +148,4 @@
 }
 
 // ========== RESUME CONTENT ==========
-// Resume Smith replaces everything after the marker above.
+// ResumeSmith replaces everything after the marker above.

--- a/docs/examples/modern-teal.typ
+++ b/docs/examples/modern-teal.typ
@@ -1,4 +1,4 @@
-// Example custom template for Resume Builder.
+// Example custom template for Resume Smith.
 // Upload this file with the "Upload Template" button.
 
 #let ink = rgb("183153")
@@ -148,4 +148,4 @@
 }
 
 // ========== RESUME CONTENT ==========
-// The Resume Builder replaces everything after the marker above.
+// Resume Smith replaces everything after the marker above.

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # Application workspace
 
-This directory contains the deployable SvelteKit application for Resume Smith. See the [project README](../README.md) for features, privacy behavior, setup, template requirements, and Vercel deployment guidance.
+This directory contains the deployable SvelteKit application for ResumeSmith. See the [project README](../README.md) for features, privacy behavior, setup, template requirements, and Vercel deployment guidance.
 
 Run all Node and npm commands from this directory:
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # Application workspace
 
-This directory contains the deployable SvelteKit application for Resume Generator. See the [project README](../README.md) for features, privacy behavior, setup, template requirements, and Vercel deployment guidance.
+This directory contains the deployable SvelteKit application for Resume Smith. See the [project README](../README.md) for features, privacy behavior, setup, template requirements, and Vercel deployment guidance.
 
 Run all Node and npm commands from this directory:
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "resume-smith",
+	"name": "resumesmith",
 	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "resume-smith",
+			"name": "resumesmith",
 			"version": "0.0.1",
 			"dependencies": {
 				"@myriaddreamin/typst-ts-renderer": "^0.7.0-rc2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "web",
+	"name": "resume-smith",
 	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "web",
+			"name": "resume-smith",
 			"version": "0.0.1",
 			"dependencies": {
 				"@myriaddreamin/typst-ts-renderer": "^0.7.0-rc2",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "web",
+	"name": "resume-smith",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "resume-smith",
+	"name": "resumesmith",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/web/src/lib/components/AppFooter.svelte
+++ b/web/src/lib/components/AppFooter.svelte
@@ -51,7 +51,7 @@
 		</div>
 
 		<p class="shrink-0">
-			{new Date().getFullYear()} Resume Builder -
+			{new Date().getFullYear()} Resume Smith -
 			<a href="https://asternberg.xyz" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700"
 				>Austin Sternberg</a
 			>

--- a/web/src/lib/components/AppFooter.svelte
+++ b/web/src/lib/components/AppFooter.svelte
@@ -51,7 +51,7 @@
 		</div>
 
 		<p class="shrink-0">
-			{new Date().getFullYear()} Resume Smith -
+			{new Date().getFullYear()} ResumeSmith -
 			<a href="https://asternberg.xyz" target="_blank" rel="noopener noreferrer" class="hover:text-gray-700"
 				>Austin Sternberg</a
 			>

--- a/web/src/lib/components/AppHeader.svelte
+++ b/web/src/lib/components/AppHeader.svelte
@@ -25,7 +25,7 @@
 <header class="bg-white shadow-sm">
 	<div class="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8">
 		<div class="flex items-center justify-between flex-wrap gap-2">
-			<h1 class="text-2xl font-bold text-gray-900">Resume Smith</h1>
+			<h1 class="text-2xl font-bold text-gray-900">ResumeSmith</h1>
 			<div class="flex gap-2">
 				<button class="secondary" onclick={onUpload}>Upload your Resume</button>
 				<button class="secondary" onclick={onTemplate}>

--- a/web/src/lib/components/AppHeader.svelte
+++ b/web/src/lib/components/AppHeader.svelte
@@ -25,7 +25,7 @@
 <header class="bg-white shadow-sm">
 	<div class="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8">
 		<div class="flex items-center justify-between flex-wrap gap-2">
-			<h1 class="text-2xl font-bold text-gray-900">Resume Builder</h1>
+			<h1 class="text-2xl font-bold text-gray-900">Resume Smith</h1>
 			<div class="flex gap-2">
 				<button class="secondary" onclick={onUpload}>Upload your Resume</button>
 				<button class="secondary" onclick={onTemplate}>

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -19,7 +19,7 @@ function seed(): ResumeData {
 				bullets: ['Built an API.'],
 			},
 		],
-		projects: [{ id: 'p1', name: 'Resume Smith', stack: '', url: '', award: '', bullets: [] }],
+		projects: [{ id: 'p1', name: 'ResumeSmith', stack: '', url: '', award: '', bullets: [] }],
 		skills: [{ id: 's1', category: 'Languages', skills: 'Python' }],
 	};
 }

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -19,7 +19,7 @@ function seed(): ResumeData {
 				bullets: ['Built an API.'],
 			},
 		],
-		projects: [{ id: 'p1', name: 'Resume Builder', stack: '', url: '', award: '', bullets: [] }],
+		projects: [{ id: 'p1', name: 'Resume Smith', stack: '', url: '', award: '', bullets: [] }],
 		skills: [{ id: 's1', category: 'Languages', skills: 'Python' }],
 	};
 }

--- a/web/src/lib/onet-insert.test.ts
+++ b/web/src/lib/onet-insert.test.ts
@@ -28,7 +28,7 @@ function seed(): ResumeData {
 				bullets: [],
 			},
 		],
-		projects: [{ id: 'p1', name: 'Resume Smith', stack: '', url: '', award: '', bullets: [] }],
+		projects: [{ id: 'p1', name: 'ResumeSmith', stack: '', url: '', award: '', bullets: [] }],
 		skills: [
 			{ id: 's1', category: 'Languages', skills: 'Python, TypeScript' },
 			{ id: 's2', category: 'Tools', skills: '' },
@@ -41,7 +41,7 @@ describe('bulletTargets', () => {
 		expect(bulletTargets(seed())).toEqual([
 			{ id: 'w1', kind: 'experience', label: 'Software Engineer at Acme' },
 			{ id: 'w2', kind: 'experience', label: 'Intern at Foo' },
-			{ id: 'p1', kind: 'project', label: 'Resume Smith' },
+			{ id: 'p1', kind: 'project', label: 'ResumeSmith' },
 		]);
 	});
 

--- a/web/src/lib/onet-insert.test.ts
+++ b/web/src/lib/onet-insert.test.ts
@@ -28,7 +28,7 @@ function seed(): ResumeData {
 				bullets: [],
 			},
 		],
-		projects: [{ id: 'p1', name: 'Resume Builder', stack: '', url: '', award: '', bullets: [] }],
+		projects: [{ id: 'p1', name: 'Resume Smith', stack: '', url: '', award: '', bullets: [] }],
 		skills: [
 			{ id: 's1', category: 'Languages', skills: 'Python, TypeScript' },
 			{ id: 's2', category: 'Tools', skills: '' },
@@ -41,7 +41,7 @@ describe('bulletTargets', () => {
 		expect(bulletTargets(seed())).toEqual([
 			{ id: 'w1', kind: 'experience', label: 'Software Engineer at Acme' },
 			{ id: 'w2', kind: 'experience', label: 'Intern at Foo' },
-			{ id: 'p1', kind: 'project', label: 'Resume Builder' },
+			{ id: 'p1', kind: 'project', label: 'Resume Smith' },
 		]);
 	});
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,8 +4,17 @@
 </script>
 
 <svelte:head>
-	<title>Resume Builder</title>
-	<meta name="description" content="Build professional resumes with customizable Typst templates" />
+	<title>Resume Smith | Forge a job-ready resume</title>
+	<meta name="application-name" content="Resume Smith" />
+	<meta
+		name="description"
+		content="Build, tailor, and export a polished resume with privacy-conscious AI assistance and customizable Typst templates."
+	/>
+	<meta property="og:title" content="Resume Smith" />
+	<meta
+		property="og:description"
+		content="Forge a polished, job-ready resume with live previews, AI-assisted tailoring, and Typst PDF export."
+	/>
 </svelte:head>
 
 {@render children()}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,13 +4,13 @@
 </script>
 
 <svelte:head>
-	<title>Resume Smith | Forge a job-ready resume</title>
-	<meta name="application-name" content="Resume Smith" />
+	<title>ResumeSmith | Forge a job-ready resume</title>
+	<meta name="application-name" content="ResumeSmith" />
 	<meta
 		name="description"
 		content="Build, tailor, and export a polished resume with privacy-conscious AI assistance and customizable Typst templates."
 	/>
-	<meta property="og:title" content="Resume Smith" />
+	<meta property="og:title" content="ResumeSmith" />
 	<meta
 		property="og:description"
 		content="Forge a polished, job-ready resume with live previews, AI-assisted tailoring, and Typst PDF export."


### PR DESCRIPTION
## Summary

- rename the product to ResumeSmith throughout the application chrome, browser metadata, package identity, and canonical documentation
- refresh the product description around forging polished, job-ready resumes
- update contribution guidance, issue forms, example-template copy, and matching test fixtures
- preserve repository URLs, persisted-data keys, and generic resume terminology because those are functional identifiers rather than product branding

## Verification

- `npm test` (216 tests passed)
- `npm run check` (0 errors and 0 warnings)
- Prettier check for every changed supported file
- Browser smoke test confirmed the title, header, and footer branding
- Vite client/server compilation completed; the final local Vercel adapter step remains blocked by Windows/OneDrive symlink permissions and will be verified by Linux CI

AI assistance: yes

Agent provider: OpenAI
Agent model: gpt-5.6-sol
Agent harness: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Updated the application header and footer branding to “ResumeSmith.”
  * Added a refreshed browser title and application name.

* **Metadata**
  * Expanded page descriptions to highlight privacy-conscious AI assistance and live previews.
  * Added Open Graph metadata for improved link previews.

* **Documentation**
  * Updated the README, contribution guide, issue templates, and example template comments to consistently reference ResumeSmith.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->