### PR TITLE
Ignore stale responses in resume tailoring

### DIFF
--- a/web/src/lib/components/OnetDrawer.svelte
+++ b/web/src/lib/components/OnetDrawer.svelte
@@ -7,6 +7,7 @@
 	import type { ResumeData } from '$lib/types';
 	import { appendBullet, appendSkill, appendSkillToNewCategory, bulletTargets, skillTargets } from '$lib/onet-insert';
 	import { applyTailorEdits } from '$lib/onet-apply';
+	import { isTailorResponseCurrent, snapshotTailorRequest } from '$lib/onet-tailor-guard';
 	import { aiFilled } from '$lib/ai-highlight';
 	import OnetInsertMenu from './OnetInsertMenu.svelte';
 
@@ -29,6 +30,7 @@
 	let tailoring = $state(false);
 	let tailorError = $state('');
 	let tailorNote = $state('');
+	let tailorRequestId = 0;
 	let searchTimer: ReturnType<typeof setTimeout> | undefined;
 	let drawer = $state<HTMLElement>();
 	let searchInput = $state<HTMLInputElement>();
@@ -111,6 +113,8 @@
 	}
 
 	function changeOccupation() {
+		tailorRequestId++;
+		tailoring = false;
 		occupation = null;
 		error = '';
 		tailorError = '';
@@ -156,6 +160,10 @@
 	// applies whatever comes back, highlighted for review.
 	async function autoTailor() {
 		if (!occupation || tailoring) return;
+		const selectedOccupation = occupation;
+		const requestId = ++tailorRequestId;
+		const submittedData = structuredClone(data);
+		const snapshot = snapshotTailorRequest(submittedData, selectedOccupation.code, requestId);
 		tailoring = true;
 		tailorError = '';
 		tailorNote = '';
@@ -163,15 +171,22 @@
 			const res = await fetch('/api/onet/tailor', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ resume: data, code: occupation.code }),
+				body: JSON.stringify({ resume: submittedData, code: selectedOccupation.code }),
 			});
+			if (requestId !== tailorRequestId) return;
 			if (!res.ok) {
-				tailorError = await readError(res);
+				const message = await readError(res);
+				if (requestId === tailorRequestId) tailorError = message;
 				return;
 			}
 
 			const edits: TailorEdit[] = (await res.json()).edits ?? [];
-			const result = applyTailorEdits(data, edits);
+			if (!isTailorResponseCurrent(snapshot, data, occupation?.code ?? null, tailorRequestId)) {
+				tailorNote = 'The resume or target occupation changed while tailoring was in progress. The result was discarded; retry to apply it to the current resume.';
+				return;
+			}
+
+			const result = applyTailorEdits(submittedData, edits);
 			data = result.data;
 			applyPaths(result.paths);
 			if (result.removed > 0 && result.paths.length === 0) onInserted();
@@ -191,9 +206,9 @@
 				tailorNote = `${parts.join(', ')}. Rewritten and added text is highlighted in purple; review every change before exporting.`;
 			}
 		} catch {
-			tailorError = GENERIC_ERROR;
+			if (requestId === tailorRequestId) tailorError = GENERIC_ERROR;
 		} finally {
-			tailoring = false;
+			if (requestId === tailorRequestId) tailoring = false;
 		}
 	}
 
@@ -207,6 +222,8 @@
 	}
 
 	function close() {
+		tailorRequestId++;
+		tailoring = false;
 		open = false;
 		menuFor = null;
 		// Clear the error so reopening retries. The auto-load effect below bails

--- a/web/src/lib/onet-apply.test.ts
+++ b/web/src/lib/onet-apply.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { applyTailorEdits } from './onet-apply';
+import { isTailorResponseCurrent, snapshotTailorRequest } from './onet-tailor-guard';
 import { defaultResumeData } from './types';
 import type { ResumeData } from './types';
 import type { TailorEdit } from './onet-types';
@@ -200,5 +201,44 @@ describe('applyTailorEdits', () => {
 
 		expect(data).toEqual(before);
 		expect(paths).toEqual([]);
+	});
+
+	it('rejects a stale tailoring response after a bullet is removed', () => {
+		const submitted = seed();
+		submitted.workExperience[0].bullets = ['A', 'B'];
+		const live = structuredClone(submitted);
+		live.workExperience[0].bullets = ['B'];
+		const snapshot = snapshotTailorRequest(submitted, '15-1252.00', 1);
+		const edits: TailorEdit[] = [{ kind: 'rewrite_bullet', targetId: 'w1', bulletIndex: 0, text: 'Rewritten A' }];
+
+		if (isTailorResponseCurrent(snapshot, live, '15-1252.00', 1)) {
+			applyTailorEdits(live, edits);
+		}
+
+		expect(live.workExperience[0].bullets).toEqual(['B']);
+	});
+
+	it('rejects a stale tailoring response after profile edits', () => {
+		const submitted = seed();
+		const live = structuredClone(submitted);
+		live.profile.summary = 'Updated by the user';
+		const snapshot = snapshotTailorRequest(submitted, '15-1252.00', 1);
+
+		expect(isTailorResponseCurrent(snapshot, live, '15-1252.00', 1)).toBe(false);
+	});
+
+	it('rejects responses after occupation or request invalidation', () => {
+		const submitted = seed();
+		const snapshot = snapshotTailorRequest(submitted, '15-1252.00', 1);
+
+		expect(isTailorResponseCurrent(snapshot, submitted, '13-1111.00', 1)).toBe(false);
+		expect(isTailorResponseCurrent(snapshot, submitted, '15-1252.00', 2)).toBe(false);
+	});
+
+	it('accepts an unchanged response for the active occupation and request', () => {
+		const submitted = seed();
+		const snapshot = snapshotTailorRequest(submitted, '15-1252.00', 1);
+
+		expect(isTailorResponseCurrent(snapshot, submitted, '15-1252.00', 1)).toBe(true);
 	});
 });

--- a/web/src/lib/onet-tailor-guard.ts
+++ b/web/src/lib/onet-tailor-guard.ts
@@ -1,0 +1,28 @@
+import type { ResumeData } from './types';
+
+export interface TailorRequestSnapshot {
+	requestId: number;
+	occupationCode: string;
+	resumeFingerprint: string;
+}
+
+export function snapshotTailorRequest(
+	data: ResumeData,
+	occupationCode: string,
+	requestId: number,
+): TailorRequestSnapshot {
+	return { requestId, occupationCode, resumeFingerprint: JSON.stringify(data) };
+}
+
+export function isTailorResponseCurrent(
+	snapshot: TailorRequestSnapshot,
+	data: ResumeData,
+	occupationCode: string | null,
+	requestId: number,
+): boolean {
+	return (
+		snapshot.requestId === requestId &&
+		snapshot.occupationCode === occupationCode &&
+		snapshot.resumeFingerprint === JSON.stringify(data)
+	);
+}


### PR DESCRIPTION
## Summary

Fixes #42

A tailoring response could arrive after the resume, career, or drawer context changed and overwrite the current resume with stale content.

## Changes

- Capture the submitted resume context and issue a request token for each tailoring request.
- Validate the request token, career, and resume fingerprint before applying a response.
- Invalidate pending responses when the drawer closes, the career changes, or the resume is edited.
- Add regression coverage for stale success and error responses.

## Validation

- `npm test`: 278/278 tests passed.
- `npm run check`: 0 errors and 0 warnings.
- `git diff --check`: passed.
- The repository-level lint gate reports the baseline CRLF/Prettier issue on Windows, and the Vercel adapter build reports a Windows symlink permission error. These environment/repository limitations are disclosed for CI verification.