### PR TITLE
fix: preserve native server initialization in production

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,3 +65,6 @@ jobs:
 
       - name: Build production application
         run: npm run build
+
+      - name: Smoke test production server startup and API routes
+        run: npm run test:production

--- a/README.md
+++ b/README.md
@@ -66,15 +66,16 @@ Free O\*NET developer keys are available from the [O\*NET Web Services developer
 
 Run these from `web/`:
 
-| Command           | Purpose                                |
-| ----------------- | -------------------------------------- |
-| `npm run dev`     | Start the development server           |
-| `npm run build`   | Create a production build              |
-| `npm run preview` | Preview a production build locally     |
-| `npm test`        | Run the Vitest suite                   |
-| `npm run check`   | Run Svelte and TypeScript diagnostics  |
-| `npm run lint`    | Check formatting with Prettier         |
-| `npm run format`  | Format the app workspace with Prettier |
+| Command                   | Purpose                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| `npm run dev`             | Start the development server                                                     |
+| `npm run build`           | Create a production build                                                        |
+| `npm run preview`         | Preview a production build locally                                               |
+| `npm test`                | Run the Vitest suite                                                             |
+| `npm run test:production` | Smoke test built server startup and API routes (run after build; no keys needed) |
+| `npm run check`           | Run Svelte and TypeScript diagnostics                                            |
+| `npm run lint`            | Check formatting with Prettier                                                   |
+| `npm run format`          | Format the app workspace with Prettier                                           |
 
 ## Custom templates
 
@@ -90,7 +91,7 @@ Use [the example custom template](docs/examples/modern-teal.typ) or download the
 
 ## Deployment
 
-API requests reject foreign `Origin` and Fetch Metadata headers. A bounded in-memory limiter allows each client IP 6 AI requests and 60 O*NET GET requests per minute, with the AI quota shared across extraction, tailoring, and template conversion. Rejections return JSON with HTTP 429 and `Retry-After`. Requests without browser headers still consume quota. Limits are best-effort per serverless instance: cold starts and multiple instances reset or multiply them, and they are not authentication or a deployment-wide spending cap. Client addresses come from the deployment adapter, which reports the `x-forwarded-for` chain; only the rightmost entry is used as the bucket key, since a caller controls everything before the address the deployment proxy appends. Adapters without client-address support share a fallback bucket. No database is used.
+API requests reject foreign `Origin` and Fetch Metadata headers. A bounded in-memory limiter allows each client IP 6 AI requests and 60 O\*NET GET requests per minute, with the AI quota shared across extraction, tailoring, and template conversion. Rejections return JSON with HTTP 429 and `Retry-After`. Requests without browser headers still consume quota. Limits are best-effort per serverless instance: cold starts and multiple instances reset or multiply them, and they are not authentication or a deployment-wide spending cap. Client addresses come from the deployment adapter, which reports the `x-forwarded-for` chain; only the rightmost entry is used as the bucket key, since a caller controls everything before the address the deployment proxy appends. Adapters without client-address support share a fallback bucket. No database is used.
 
 Before public deployment, configure provider budget alerts and review available account spending controls. Monitor usage and revoke the key or disable AI routes if necessary; do not rely on budget alerts or the in-memory limiter as a hard spending ceiling. Apply deployment-level firewall controls when available for your plan.
 

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
 		"lint": "prettier --check .",
-		"test": "vitest run"
+		"test": "vitest run",
+		"test:production": "node --test scripts/production-smoke.mjs"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",

--- a/web/scripts/production-smoke.mjs
+++ b/web/scripts/production-smoke.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { Server } from '../.svelte-kit/output/server/index.js';
+import { manifest } from '../.svelte-kit/output/server/manifest.js';
+
+// Initialize immediately, as the Vercel entrypoint does. A browser top-level-await
+// transform on server chunks previously left Server's options undefined here.
+const server = new Server(manifest);
+await server.init({ env: {} });
+
+for (const [path, method, status, code] of [
+	['/api/onet/search?keyword=engineer', 'GET', 502, 'auth'],
+	['/api/onet/occupation/15-1252.00', 'GET', 502, 'auth'],
+	['/api/extract', 'POST', 400, 'invalid_file'],
+	['/api/onet/tailor', 'POST', 400, 'invalid_code'],
+	['/api/template/convert', 'POST', 400, 'invalid_file'],
+]) {
+	test(`production server handles ${method} ${path}`, async () => {
+		const response = await server.respond(
+			new Request(`https://example.test${path}`, {
+				method,
+				headers: { origin: 'https://example.test', 'content-type': 'application/json' },
+				...(method === 'POST' ? { body: '{}' } : {}),
+			}),
+			{ getClientAddress: () => '127.0.0.1' },
+		);
+		assert.equal(response.status, status);
+		assert.equal((await response.json()).error.code, code);
+	});
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,7 +5,13 @@ import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 
 export default defineConfig({
-	plugins: [wasm(), topLevelAwait(), sveltekit()],
+	// Node supports native top-level await. Rewriting server chunks delays SvelteKit's
+	// options initialization until after the Vercel function constructs its Server.
+	plugins: [
+		wasm(),
+		{ ...topLevelAwait(), applyToEnvironment: (environment) => environment.name === 'client' },
+		sveltekit(),
+	],
 	optimizeDeps: {
 		exclude: ['@myriaddreamin/typst.ts'],
 	},


### PR DESCRIPTION
﻿Production API functions crashed in Server.init before reaching either OpenAI or O*NET, returning FUNCTION_INVOCATION_FAILED. Restrict the top-level-await compatibility transform to the client environment so Node initializes SvelteKit's server configuration natively.

Add a production smoke test that immediately initializes the built server and exercises all five API routes without credentials or upstream requests. Run it after the production build in CI.

Validation: 274 unit tests and Svelte/TypeScript checks pass; Linux Node 22 production build and all five production smoke tests pass. Windows packaging hits the adapter's symlink permission restriction; Windows formatting warnings are caused by checkout line endings.

Agent provider: OpenAI
Agent model: GPT-6
Agent harness: Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added production smoke testing to verify that the built application starts successfully and that key API routes return expected responses.
  - Production checks now run as part of the test workflow.

- **Documentation**
  - Documented the production smoke test command in the local development guide.
  - Corrected product-name formatting in the deployment documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->