### PR TITLE
feat: add reset to default for color settings

### DIFF
--- a/web/src/lib/components/forms/ColorsForm.svelte
+++ b/web/src/lib/components/forms/ColorsForm.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 	import type { ResumeData } from '$lib/types';
+	import { defaultResumeData } from '$lib/types';
 
 	let { data }: { data: ResumeData } = $props();
+
+	function resetColorSettings() {
+		data.colors = { ...defaultResumeData.colors };
+	}
 </script>
 
 <div class="space-y-4">
-	<h2 class="text-lg font-semibold">Color Settings</h2>
+	<div class="flex items-center justify-between">
+		<h2 class="text-lg font-semibold">Color Settings</h2>
+		<button class="secondary text-sm" onclick={resetColorSettings}>Reset to Default</button>
+	</div>
 	<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 		<div>
 			<label>Header Color</label><input


### PR DESCRIPTION
## Summary

Adds a Reset to Default action to the Colors settings, following the existing reset behavior used in the Fonts form.

## Changes

- Added a Reset to Default button to the Colors form
- Restores header, text, accent, and link colors from `defaultResumeData.colors`
- Uses a fresh copy of the default colors to avoid mutating the canonical defaults
- Leaves resume content, fonts, layout, section order, and other settings unchanged

## Testing

- Changed all four color settings
- Confirmed the preview updated
- Reset all four colors to their defaults
- Confirmed unrelated resume settings remained unchanged
- Changed a color again after resetting and confirmed Reset to Default still restored the original value

Closes #54

AI assistance: no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Reset to Default” option for restoring the default color settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->